### PR TITLE
廃止になった `audio_opus_params_clock_rate` を削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,8 @@
 
 ## develop
 
+- [FIX] 廃止になった `audio_opus_params_clock_rate` を削除する
+
 ## 2022.14.0 (2022-10-05)
 
 - [ADD] SoraSignaling に `GetConnectionID`, `GetConnectedSignalingURL`, `IsConnectedDataChannel`, `IsConnectedWebsocket` 関数を追加

--- a/include/sora/sora_signaling.h
+++ b/include/sora/sora_signaling.h
@@ -67,7 +67,6 @@ struct SoraSignalingConfig {
   std::string audio_codec_type = "";
   int video_bit_rate = 0;
   int audio_bit_rate = 0;
-  int audio_opus_params_clock_rate = 0;
   boost::json::value metadata;
   boost::json::value signaling_notify_metadata;
   std::string role = "sendonly";

--- a/src/sora_signaling.cpp
+++ b/src/sora_signaling.cpp
@@ -291,8 +291,7 @@ void SoraSignaling::DoSendConnect(bool redirect) {
   if (!config_.audio) {
     m["audio"] = false;
   } else if (config_.audio && config_.audio_codec_type.empty() &&
-             config_.audio_bit_rate == 0 &&
-             config_.audio_opus_params_clock_rate == 0) {
+             config_.audio_bit_rate == 0) {
     m["audio"] = true;
   } else {
     m["audio"] = boost::json::object();
@@ -301,11 +300,6 @@ void SoraSignaling::DoSendConnect(bool redirect) {
     }
     if (config_.audio_bit_rate != 0) {
       m["audio"].as_object()["bit_rate"] = config_.audio_bit_rate;
-    }
-    if (config_.audio_opus_params_clock_rate != 0) {
-      m["audio"].as_object()["opus_params"] = boost::json::object();
-      m["audio"].as_object()["opus_params"].as_object()["clock_rate"] =
-          config_.audio_opus_params_clock_rate;
     }
   }
 


### PR DESCRIPTION
Sora 2021.2.0 にて opus_params の clock_rate は廃止されたため、削除します。