### PR TITLE
hello.cpp の Lyra 利用時の Config  設定誤りを修正

### DIFF
--- a/test/hello.cpp
+++ b/test/hello.cpp
@@ -71,7 +71,7 @@ void HelloSora::Run() {
   if (config_.mode == HelloSoraConfig::Mode::Lyra) {
     config.video = false;
     config.sora_client = "Hello Sora with Lyra";
-    config.video_codec_type = "LYRA";
+    config.audio_codec_type = "LYRA";
   }
   conn_ = sora::SoraSignaling::Create(config);
 


### PR DESCRIPTION
test/hello.cpp にて `video_codec_type` に "LYRA" を指定していますが `audio_codec_type` の誤りかと思われたので修正しました。