### PR TITLE
映像コーデックパラメータを指定可能にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@
 
 ## develop
 
+- [ADD] 映像コーデックパラメータを指定可能にする
+    - `SoraSignalingConfig` に以下のフィールドを追加する:
+        - `video_vp9_params`
+        - `video_av1_params`
+        - `video_h264_params`
+    - 値は単なる JSON 値で C++ SDK は中身のバリーデーションなどは行わない
+    - @sile
 - [UPDATE] CMake を 3.26.4 に上げる
     - @torikizi
 

--- a/include/sora/sora_signaling.h
+++ b/include/sora/sora_signaling.h
@@ -78,6 +78,9 @@ struct SoraSignalingConfig {
   boost::optional<bool> audio_codec_lyra_usedtx;
   int video_bit_rate = 0;
   int audio_bit_rate = 0;
+  boost::json::value video_vp9_params;
+  boost::json::value video_av1_params;
+  boost::json::value video_h264_params;
   std::string audio_streaming_language_code;
   boost::json::value metadata;
   boost::json::value signaling_notify_metadata;

--- a/src/sora_signaling.cpp
+++ b/src/sora_signaling.cpp
@@ -351,12 +351,8 @@ void SoraSignaling::DoSendConnect(bool redirect) {
   if (!config_.video) {
     // video: false の場合はそのまま設定
     m["video"] = false;
-  } else if (config_.video && config_.video_codec_type.empty() &&
-             config_.video_bit_rate == 0) {
-    // video: true の場合、その他のオプションの設定が行われてなければ true を設定
-    m["video"] = true;
   } else {
-    // それ以外はちゃんとオプションを設定する
+    // video: true の場合は、ちゃんとオプションを設定する
     m["video"] = boost::json::object();
     if (!config_.video_codec_type.empty()) {
       m["video"].as_object()["codec_type"] = config_.video_codec_type;
@@ -372,6 +368,11 @@ void SoraSignaling::DoSendConnect(bool redirect) {
     }
     if (!config_.video_h264_params.is_null()) {
       m["video"].as_object()["h264_params"] = config_.video_h264_params;
+    }
+
+    // オプションの設定が行われてなければ単に true を設定
+    if (m["video"].as_object().empty()) {
+      m["video"] = true;
     }
   }
 

--- a/src/sora_signaling.cpp
+++ b/src/sora_signaling.cpp
@@ -364,6 +364,15 @@ void SoraSignaling::DoSendConnect(bool redirect) {
     if (config_.video_bit_rate != 0) {
       m["video"].as_object()["bit_rate"] = config_.video_bit_rate;
     }
+    if (!config_.video_vp9_params.is_null()) {
+      m["video"].as_object()["vp9_params"] = config_.video_vp9_params;
+    }
+    if (!config_.video_av1_params.is_null()) {
+      m["video"].as_object()["av1_params"] = config_.video_av1_params;
+    }
+    if (!config_.video_h264_params.is_null()) {
+      m["video"].as_object()["h264_params"] = config_.video_h264_params;
+    }
   }
 
   if (!config_.audio) {


### PR DESCRIPTION
Sora が次のリリースでシグナリング時に映像 (H.264, VP9, AV1）のコーデックパラメータを指定可能になるので、それに追従するための PR です。

以下の手順で Sora に接続して期待通りの内容が送信されていることを確認しました:
```console
$ cat test.json
{
    "signaling_urls": ["ws://localhost:5000/signaling"],
    "channel_id": "sora",
    "role": "sendonly",
    "mode": "hello"
}

$ git diff
diff --git a/test/hello.cpp b/test/hello.cpp
index fc4f9b3..cd3ff91 100644
--- a/test/hello.cpp
+++ b/test/hello.cpp
@@ -67,7 +67,9 @@ void HelloSora::Run() {
   config.channel_id = config_.channel_id;
   config.sora_client = "Hello Sora";
   config.role = config_.role;
-  config.video_codec_type = "H264";
+  config.video_codec_type = "AV1";
+  config.video_av1_params = boost::json::object();
+  config.video_av1_params.as_object()["profile"] = 0;  // ここを他の型や無効な値にすると接続に失敗する
   config.multistream = true;
   if (config_.mode == HelloSoraConfig::Mode::Lyra) {
     config.video = false;

$ python3 run.py --test macos_arm64
$ _build/macos_arm64/release/test/hello test.json
```