### PR TITLE
Jetson Orin で AV1 エンコードした時にシーケンスヘッダーが入っていないのを何とかする

### DIFF
--- a/include/sora/hwenc_jetson/jetson_video_encoder.h
+++ b/include/sora/hwenc_jetson/jetson_video_encoder.h
@@ -138,6 +138,8 @@ class JetsonVideoEncoder : public webrtc::VideoEncoder {
   std::queue<NvBuffer*>* enc0_buffer_queue_;
   int output_plane_fd_[32];
   webrtc::EncodedImage encoded_image_;
+  webrtc::ScalabilityMode scalability_mode_;
+  std::vector<uint8_t> obu_seq_header_;
 };
 
 }  // namespace sora


### PR DESCRIPTION
他のユーザーが途中から受信した時に映像が出ない問題を修正します。

原因としては H.264 の SPS/PPS に相当する（と思われる）OBU_SEQUENCE_HEADER が、エンコードした最初の１フレーム目以外に存在してないために、正しくデコードができないというものです。
I フレームの OBU_FRAME の手前に、最初の１フレーム目で流れてきた OBU_SEQUENCE_HEADER をくっつけることで修正しています。