### PR TITLE
Sora C++ SDK を利用する側で _LIBCPP_HARDENING_MODE を定義せずにすむように CMakeLists.tx…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -397,6 +397,7 @@ elseif (SORA_TARGET_OS STREQUAL "android")
       _LIBCPP_DISABLE_VISIBILITY_ANNOTATIONS
       _LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS
       _LIBCPP_ENABLE_NODISCARD
+      _LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE
       # https://github.com/boostorg/container_hash/issues/22 と同じ問題が clang-15 でも起きるので、これを手動で定義して回避する
       BOOST_NO_CXX98_FUNCTION_BASE
   )


### PR DESCRIPTION
…t の target_compile_definitions で定義する