### PR TITLE
HWA 利用の判定を `#if defined(USE_*_ENCODER)` という使い方で統一するように修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [FIX] HWA 利用の判定を `#if defined(USE_*_ENCODER)` という使い方で統一するように修正
+  - @melpon
+
 ## 2024.4.0 (2024-03-13)
 
 - [ADD] test/hello.cpp に video, audio フラグを追加

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,9 +147,9 @@ target_include_directories(sora PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}/include)
 target_include_directories(sora INTERFACE $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}> $<INSTALL_INTERFACE:include>)
 target_compile_definitions(sora
   PRIVATE
-    USE_NVCODEC_ENCODER=$<BOOL:${USE_NVCODEC_ENCODER}>
-    USE_JETSON_ENCODER=$<BOOL:${USE_JETSON_ENCODER}>
-    USE_VPL_ENCODER=$<BOOL:${USE_VPL_ENCODER}>
+    $<$<BOOL:${USE_NVCODEC_ENCODER}>:USE_NVCODEC_ENCODER>
+    $<$<BOOL:${USE_JETSON_ENCODER}>:USE_JETSON_ENCODER>
+    $<$<BOOL:${USE_VPL_ENCODER}>:USE_VPL_ENCODER>
 )
 
 # 指定したライブラリを自身の静的ライブラリにバンドルする

--- a/src/cuda_context_cuda.cpp
+++ b/src/cuda_context_cuda.cpp
@@ -2,7 +2,7 @@
 
 #include "sora/cuda_context.h"
 
-#if !USE_NVCODEC_ENCODER
+#if !defined(USE_NVCODEC_ENCODER)
 
 namespace sora {
 

--- a/src/sora_video_decoder_factory.cpp
+++ b/src/sora_video_decoder_factory.cpp
@@ -23,7 +23,7 @@
 #include "sora/android/android_video_factory.h"
 #endif
 
-#if USE_NVCODEC_ENCODER
+#if defined(USE_NVCODEC_ENCODER)
 #include "sora/hwenc_nvcodec/nvcodec_video_decoder.h"
 #endif
 
@@ -31,7 +31,7 @@
 #include "sora/hwenc_vpl/vpl_video_decoder.h"
 #endif
 
-#if USE_JETSON_ENCODER
+#if defined(USE_JETSON_ENCODER)
 #include "sora/hwenc_jetson/jetson_video_decoder.h"
 #endif
 
@@ -125,7 +125,7 @@ SoraVideoDecoderFactoryConfig GetDefaultVideoDecoderFactoryConfig(
   }
 #endif
 
-#if USE_NVCODEC_ENCODER
+#if defined(USE_NVCODEC_ENCODER)
   if (NvCodecVideoDecoder::IsSupported(cuda_context,
                                        sora::CudaVideoCodec::VP8)) {
     config.decoders.insert(
@@ -205,7 +205,7 @@ SoraVideoDecoderFactoryConfig GetDefaultVideoDecoderFactoryConfig(
   }
 #endif
 
-#if USE_JETSON_ENCODER
+#if defined(USE_JETSON_ENCODER)
   if (JetsonVideoDecoder::IsSupportedVP8()) {
     config.decoders.insert(
         config.decoders.begin(),

--- a/src/sora_video_encoder_factory.cpp
+++ b/src/sora_video_encoder_factory.cpp
@@ -26,15 +26,15 @@
 #include "sora/android/android_video_factory.h"
 #endif
 
-#if USE_NVCODEC_ENCODER
+#if defined(USE_NVCODEC_ENCODER)
 #include "sora/hwenc_nvcodec/nvcodec_h264_encoder.h"
 #endif
 
-#if USE_VPL_ENCODER
+#if defined(USE_VPL_ENCODER)
 #include "sora/hwenc_vpl/vpl_video_encoder.h"
 #endif
 
-#if USE_JETSON_ENCODER
+#if defined(USE_JETSON_ENCODER)
 #include "sora/hwenc_jetson/jetson_video_encoder.h"
 #endif
 
@@ -178,7 +178,7 @@ SoraVideoEncoderFactoryConfig GetDefaultVideoEncoderFactoryConfig(
   }
 #endif
 
-#if USE_NVCODEC_ENCODER
+#if defined(USE_NVCODEC_ENCODER)
   if (NvCodecH264Encoder::IsSupported(cuda_context)) {
     config.encoders.insert(
         config.encoders.begin(),
@@ -193,7 +193,7 @@ SoraVideoEncoderFactoryConfig GetDefaultVideoEncoderFactoryConfig(
   }
 #endif
 
-#if USE_VPL_ENCODER
+#if defined(USE_VPL_ENCODER)
   auto session = VplSession::Create();
   if (VplVideoEncoder::IsSupported(session, webrtc::kVideoCodecVP8)) {
     config.encoders.insert(
@@ -241,7 +241,7 @@ SoraVideoEncoderFactoryConfig GetDefaultVideoEncoderFactoryConfig(
   }
 #endif
 
-#if USE_JETSON_ENCODER
+#if defined(USE_JETSON_ENCODER)
   if (JetsonVideoEncoder::IsSupportedVP8()) {
     config.encoders.insert(config.encoders.begin(),
                            VideoEncoderConfig(

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -178,7 +178,7 @@ std::string Version::GetEnvironmentName() {
     break;
   }
 
-#if USE_JETSON_ENCODER
+#if defined(USE_JETSON_ENCODER)
   // Jetson 系の場合、更に詳細な情報を取得する
 
   // nvidia-l4t-core のバージョンを拾う


### PR DESCRIPTION
`#if USE_*_ENCODER` が正しい使い方なんだけど、`#if defined(USE_*_ENCODER)` という使い方をしている箇所があった。

defined の部分を取り除いてもいいのだけど、そもそも間違えてもビルドが通ってしまうのが問題なので、0 か 1 で定義するんじゃなく、不要な場合は未定義にして、定義する場合は空文字列として定義し、全体を `#if defined(USE_*_ENCODER)` と記述するようにしておく。
そうすれば `#if USE_*_ENCODER` と間違えて書いてしまっても、空の式になってコンパイルエラーになる。
