### PR TITLE
build_webrtc でも __assertion_handler のコピーが必要だった

### DIFF
--- a/buildbase.py
+++ b/buildbase.py
@@ -446,10 +446,24 @@ def build_webrtc(platform, webrtc_build_dir, webrtc_build_args, debug):
         copyfile_if_different(src_config, dst_config)
 
         # __assertion_handler をコピーする
-        copyfile_if_different(
-            os.path.join(webrtc_source_dir, "src", "buildtools", "third_party", "libc++", "__assertion_handler"),
-            os.path.join(webrtc_source_dir, "src", "third_party", "libc++", "src", "include", "__assertion_handler"),
+        src_assertion = os.path.join(
+            webrtc_source_dir,
+            "src",
+            "buildtools",
+            "third_party",
+            "libc++",
+            "__assertion_handler",
         )
+        dst_assertion = os.path.join(
+            webrtc_source_dir,
+            "src",
+            "third_party",
+            "libc++",
+            "src",
+            "include",
+            "__assertion_handler",
+        )
+        copyfile_if_different(src_assertion, dst_assertion)
 
 
 class WebrtcInfo(NamedTuple):

--- a/buildbase.py
+++ b/buildbase.py
@@ -445,6 +445,12 @@ def build_webrtc(platform, webrtc_build_dir, webrtc_build_args, debug):
         )
         copyfile_if_different(src_config, dst_config)
 
+        # __assertion_handler をコピーする
+        copyfile_if_different(
+            os.path.join(webrtc_source_dir, "src", "buildtools", "third_party", "libc++", "__assertion_handler"),
+            os.path.join(webrtc_source_dir, "src", "third_party", "libc++", "src", "include", "__assertion_handler"),
+        )
+
 
 class WebrtcInfo(NamedTuple):
     version_file: str


### PR DESCRIPTION
## 背景

https://github.com/shiguredo/sora-cpp-sdk/pull/79 で install_llvm で __assertion_handler をコピーする処理を追加しましたが、 `--webrtc-build-dir` が指定されている場合は install_llvm が実行されず __assertion_handler のコピーが行われないという問題がありました

## 修正

build_webrtc でも __assertion_handler をコピーするように修正しました

