### PR TITLE
VplVideoEncoderImpl / VplVideoDecoderImpl の名前を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -15,6 +15,8 @@
 
 - [CHANGE] 別リポジトリに分かれていた Sora C++ SDK のサンプル集を examples/ 以下のディレクトリに統合する
   - @melpon
+- [CHANGE] VplVideoDecoderImpl の ImplementationName を oneVPL から libvpl に変更する
+  - @enm10k
 - [UPDATE] libwebrtc を `m122.6261.1.0` にあげる
   - Ubuntu のビルドを通すために、 __assertion_handler というファイルをコピーする必要があった
   - @miosakuma @enm10k
@@ -28,6 +30,8 @@
   - @enm10k
 - [FIX] HWA 利用の判定を `#if defined(USE_*_ENCODER)` という使い方で統一するように修正
   - @melpon
+- [FIX] VplVideoEncoderImpl の implementation_name の値が誤っていたため libvpl に修正する
+  - @enm10k
 
 ## 2024.4.0 (2024-03-13)
 

--- a/run.py
+++ b/run.py
@@ -407,7 +407,7 @@ def install_deps(
             }
             install_cuda_windows(**install_cuda_args)
 
-        # oneVPL
+        # Intel VPL
         if platform.target.os in ("windows", "ubuntu") and platform.target.arch == "x86_64":
             install_vpl_args = {
                 "version": version["VPL_VERSION"],

--- a/src/hwenc_vpl/vaapi_utils.h
+++ b/src/hwenc_vpl/vaapi_utils.h
@@ -19,7 +19,7 @@ or https://software.intel.com/en-us/media-client-solutions-support.
 // libva
 #include <va/va.h>
 
-// oneVPL
+// Intel VPL
 #include <vpl/mfxdefs.h>
 
 namespace sora {

--- a/src/hwenc_vpl/vpl_session_impl.cpp
+++ b/src/hwenc_vpl/vpl_session_impl.cpp
@@ -2,7 +2,7 @@
 
 #include <rtc_base/logging.h>
 
-// oneVPL
+// Intel VPL
 #include <vpl/mfxdispatcher.h>
 #include <vpl/mfxvideo.h>
 
@@ -77,9 +77,9 @@ std::shared_ptr<VplSession> VplSession::Create() {
     return nullptr;
   }
 
-  RTC_LOG(LS_VERBOSE) << "oneVPL Implementation: "
+  RTC_LOG(LS_VERBOSE) << "Intel VPL Implementation: "
                       << (impl == MFX_IMPL_SOFTWARE ? "SOFTWARE" : "HARDWARE");
-  RTC_LOG(LS_VERBOSE) << "oneVPL Version: " << ver.Major << "." << ver.Minor;
+  RTC_LOG(LS_VERBOSE) << "Intel VPL Version: " << ver.Major << "." << ver.Minor;
   return session;
 }
 

--- a/src/hwenc_vpl/vpl_session_impl.h
+++ b/src/hwenc_vpl/vpl_session_impl.h
@@ -3,7 +3,7 @@
 
 #include <iostream>
 
-// oneVPL
+// Intel VPL
 #include <vpl/mfxvideo++.h>
 
 #include "sora/hwenc_vpl/vpl_session.h"

--- a/src/hwenc_vpl/vpl_utils.h
+++ b/src/hwenc_vpl/vpl_utils.h
@@ -4,15 +4,15 @@
 // WebRTC
 #include <api/video/video_codec_type.h>
 
-// oneVPL
+// Intel VPL
 #include <vpl/mfxdefs.h>
 
-#define VPL_CHECK_RESULT(P, X, ERR)                 \
-  {                                                 \
-    if ((X) > (P)) {                                \
-      RTC_LOG(LS_ERROR) << "oneVPL Error: " << ERR; \
-      throw ERR;                                    \
-    }                                               \
+#define VPL_CHECK_RESULT(P, X, ERR)                    \
+  {                                                    \
+    if ((X) > (P)) {                                   \
+      RTC_LOG(LS_ERROR) << "Intel VPL Error: " << ERR; \
+      throw ERR;                                       \
+    }                                                  \
   }
 
 namespace sora {

--- a/src/hwenc_vpl/vpl_video_decoder.cpp
+++ b/src/hwenc_vpl/vpl_video_decoder.cpp
@@ -332,7 +332,7 @@ int32_t VplVideoDecoderImpl::Release() {
 }
 
 const char* VplVideoDecoderImpl::ImplementationName() const {
-  return "oneVPL";
+  return "libvpl";
 }
 
 bool VplVideoDecoderImpl::InitVpl() {

--- a/src/hwenc_vpl/vpl_video_decoder.cpp
+++ b/src/hwenc_vpl/vpl_video_decoder.cpp
@@ -13,7 +13,7 @@
 #include <rtc_base/time_utils.h>
 #include <third_party/libyuv/include/libyuv/convert.h>
 
-// oneVPL
+// Intel VPL
 #include <vpl/mfxdefs.h>
 #include <vpl/mfxvideo++.h>
 #include <vpl/mfxvp8.h>
@@ -160,7 +160,7 @@ std::unique_ptr<MFXVideoDECODE> VplVideoDecoderImpl::CreateDecoderInternal(
   // Query した上で Init しても MFX_ERR_UNSUPPORTED になることがあるので
   // 本来 Init が不要な時も常に呼ぶようにして確認する
   /*if (init)*/ {
-    // Initialize the oneVPL encoder
+    // Initialize the Intel VPL encoder
     sts = decoder->Init(&param);
     if (sts != MFX_ERR_NONE) {
       RTC_LOG(LS_VERBOSE) << "Init failed: codec=" << CodecToString(codec)

--- a/src/hwenc_vpl/vpl_video_encoder.cpp
+++ b/src/hwenc_vpl/vpl_video_encoder.cpp
@@ -12,7 +12,7 @@
 #include <rtc_base/logging.h>
 #include <rtc_base/synchronization/mutex.h>
 
-// oneVPL
+// Intel VPL
 #include <vpl/mfxvideo++.h>
 #include <vpl/mfxvp8.h>
 

--- a/src/hwenc_vpl/vpl_video_encoder.cpp
+++ b/src/hwenc_vpl/vpl_video_encoder.cpp
@@ -521,7 +521,7 @@ void VplVideoEncoderImpl::SetRates(const RateControlParameters& parameters) {
 webrtc::VideoEncoder::EncoderInfo VplVideoEncoderImpl::GetEncoderInfo() const {
   webrtc::VideoEncoder::EncoderInfo info;
   info.supports_native_handle = true;
-  info.implementation_name = "NvCodec H264";
+  info.implementation_name = "libvpl";
   info.scaling_settings = webrtc::VideoEncoder::ScalingSettings(
       kLowH264QpThreshold, kHighH264QpThreshold);
   info.is_hardware_accelerated = true;


### PR DESCRIPTION
## 変更内容

- VplVideoEncoderImpl の implementation_name が誤っていたので libvpl に修正しました
- VplVideoDecoderImpl の ImplementationName が oneVPL になっていたので、こちらも修正しています
  - oneVPL という名前は今後使われなくなるため、併せて修正してはどうかという考えです