### PR TITLE
E2E で sora_client を設定するのをやめる

### DIFF
--- a/test/connect_disconnect.cpp
+++ b/test/connect_disconnect.cpp
@@ -60,7 +60,6 @@ class SoraClient : public std::enable_shared_from_this<SoraClient>,
     config.observer = shared_from_this();
     config.signaling_urls = config_.signaling_urls;
     config.channel_id = config_.channel_id;
-    config.sora_client = "Hello Sora";
     config.role = config_.role;
     config.video_codec_type = "H264";
     config.multistream = true;

--- a/test/datachannel.cpp
+++ b/test/datachannel.cpp
@@ -43,7 +43,6 @@ class SoraClient : public std::enable_shared_from_this<SoraClient>,
     config.observer = shared_from_this();
     config.signaling_urls = config_.signaling_urls;
     config.channel_id = config_.channel_id;
-    config.sora_client = "Hello Sora";
     config.role = config_.role;
     config.video = false;
     config.audio = false;

--- a/test/e2e.cpp
+++ b/test/e2e.cpp
@@ -85,7 +85,6 @@ class SoraClient : public std::enable_shared_from_this<SoraClient>,
     config.pc_factory = pc_factory;
     config.io_context = ioc_.get();
     config.observer = shared_from_this();
-    config.sora_client = "Sora C++ E2E Test Client";
     config.role = "sendonly";
     config.video = true;
     config.audio = false;

--- a/test/hello.cpp
+++ b/test/hello.cpp
@@ -63,7 +63,6 @@ void HelloSora::Run() {
   config.observer = shared_from_this();
   config.signaling_urls = config_.signaling_urls;
   config.channel_id = config_.channel_id;
-  config.sora_client = "Hello Sora";
   config.role = config_.role;
   config.video = config_.video;
   config.audio = config_.audio;


### PR DESCRIPTION
## 変更内容

E2E 時に デフォルトの sora_client を上書きして設定することをやめました
上書きして設定することで、デフォルトの sora_client に含まれる Sora C++ SDK のバージョン情報が含まれなくなってしまうためです