### PR TITLE
Safari から送信された H.264 のデータを VPL デコーダで受信すると遅延が起きたりセグフォすることがあるのを修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,9 @@
 
 ## develop
 
+- [FIX] VPL デコーダで遅延が起きたりセグフォすることがあるのを修正
+  - @melpon
+
 ## 2024.6.0 (2024-04-01)
 
 - [CHANGE] `VplVideoDecoderImpl` の `ImplementationName` を `oneVPL` から `libvpl` に変更する

--- a/src/hwenc_vpl/vpl_video_decoder.cpp
+++ b/src/hwenc_vpl/vpl_video_decoder.cpp
@@ -302,6 +302,7 @@ int32_t VplVideoDecoderImpl::Decode(const webrtc::EncodedImage& input_image,
     VPL_CHECK_RESULT(sts, MFX_ERR_NONE, sts);
 
     uint64_t pts = bitstreams_.front()->pts;
+    free(bitstreams_.front());
     bitstreams_.pop();
     // NV12 から I420 に変換
     rtc::scoped_refptr<webrtc::I420Buffer> i420_buffer =

--- a/src/hwenc_vpl/vpl_video_decoder.cpp
+++ b/src/hwenc_vpl/vpl_video_decoder.cpp
@@ -1,6 +1,7 @@
 #include "sora/hwenc_vpl/vpl_video_decoder.h"
 
 #include <iostream>
+#include <queue>
 #include <thread>
 
 // WebRTC

--- a/src/hwenc_vpl/vpl_video_decoder.cpp
+++ b/src/hwenc_vpl/vpl_video_decoder.cpp
@@ -69,6 +69,8 @@ class VplVideoDecoderImpl : public VplVideoDecoder {
   std::unique_ptr<MFXVideoDECODE> decoder_;
   std::vector<uint8_t> surface_buffer_;
   std::vector<mfxFrameSurface1> surfaces_;
+  std::vector<uint8_t> bitstream_buffer_;
+  mfxBitstream bitstream_;
 };
 
 VplVideoDecoderImpl::VplVideoDecoderImpl(std::shared_ptr<VplSession> session,
@@ -192,13 +194,11 @@ int32_t VplVideoDecoderImpl::Decode(const webrtc::EncodedImage& input_image,
     return WEBRTC_VIDEO_CODEC_ERR_PARAMETER;
   }
 
-  mfxBitstream bs;
-  memset(&bs, 0, sizeof(mfxBitstream));
-  std::vector<uint8_t> buf;
-  buf.assign(input_image.data(), input_image.data() + input_image.size());
-  bs.Data = buf.data();
-  bs.DataLength = input_image.size();
-  bs.MaxLength = input_image.size();
+  if (bitstream_.MaxLength < bitstream_.DataLength + input_image.size()) {
+    bitstream_buffer_.resize(bitstream_.DataLength + input_image.size());
+    bitstream_.MaxLength = bitstream_.DataLength + bitstream_buffer_.size();
+    bitstream_.Data = bitstream_buffer_.data();
+  }
   //printf("size=%zu\n", input_image.size());
   //for (size_t i = 0; i < input_image.size(); i++) {
   //  const uint8_t* p = input_image.data();
@@ -209,6 +209,13 @@ int32_t VplVideoDecoderImpl::Decode(const webrtc::EncodedImage& input_image,
   //    break;
   //  }
   //}
+
+  memmove(bitstream_.Data, bitstream_.Data + bitstream_.DataOffset,
+          bitstream_.DataLength);
+  bitstream_.DataOffset = 0;
+  memcpy(bitstream_.Data + bitstream_.DataLength, input_image.data(),
+         input_image.size());
+  bitstream_.DataLength += input_image.size();
 
   // 使ってない入力サーフェスを取り出す
   auto surface =
@@ -226,7 +233,8 @@ int32_t VplVideoDecoderImpl::Decode(const webrtc::EncodedImage& input_image,
     mfxFrameSurface1* out_surface = nullptr;
 
     while (true) {
-      sts = decoder_->DecodeFrameAsync(&bs, &*surface, &out_surface, &syncp);
+      sts = decoder_->DecodeFrameAsync(&bitstream_, &*surface, &out_surface,
+                                       &syncp);
       if (sts == MFX_WRN_DEVICE_BUSY) {
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
         continue;
@@ -322,6 +330,12 @@ bool VplVideoDecoderImpl::InitVpl() {
 
   RTC_LOG(LS_INFO) << "Decoder NumFrameSuggested="
                    << alloc_request_.NumFrameSuggested;
+
+  // 入力ビットストリーム
+  bitstream_buffer_.resize(1024 * 1024);
+  memset(&bitstream_, 0, sizeof(bitstream_));
+  bitstream_.MaxLength = bitstream_buffer_.size();
+  bitstream_.Data = bitstream_buffer_.data();
 
   // 必要な枚数分の出力サーフェスを作る
   {

--- a/src/hwenc_vpl/vpl_video_decoder.cpp
+++ b/src/hwenc_vpl/vpl_video_decoder.cpp
@@ -393,6 +393,10 @@ void VplVideoDecoderImpl::ReleaseVpl() {
     decoder_->Close();
   }
   decoder_.reset();
+  while (!bitstreams_.empty()) {
+    free(bitstreams_.front());
+    bitstreams_.pop();
+  }
 }
 
 ////////////////////////


### PR DESCRIPTION
#91 に余計な実験的なコミットを入れてしまったので作り直しです。

- 遅延は、Decode 関数の中で１回しかデコードしないため、MFX_ERR_MORE_DATA やその他復帰可能なエラーが起きた時に、デコードしないといけないデータがずっと溜まっていってしまうのが原因
  - →Decode 関数の中で MFX_ERR_MORE_DATA が出るまでひたすらデコードするようにしました
- セグフォは、DecodeFrameAsync を呼んだ後に mfxBitstream のバッファを動かしたり削除していたのが原因っぽい
  - →mfxBitstream のデータをキューにして、DecodeFrameAsync 以降は一切触らないようにすることで直しました
  - →ちゃんと mfxBitstream が消費される（＝MORE_DATA が返却される）までループを回せばキューにする必要すら無さそうだったので、キューを削除しました。
