### PR TITLE
SoraSignalingConfig に video_h265_params を追加する & sumomo に --video-h264-params, --video-h265-params を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -17,6 +17,10 @@
   - @enm10k
 - [ADD] sumomo に `--openh264` と `--use-hardware-encoder` オプションを追加
   - @melpon
+- [ADD] sumomo に `--video-h264-params` と `--video-h265-params` オプションを追加
+  - @enm10k
+- [ADD] SoraSignalingConfig に `video_h265_params` を追加
+  - @enm10k
 
 ## 2024.6.1 (2024-04-16)
 

--- a/examples/sumomo/src/sumomo.cpp
+++ b/examples/sumomo/src/sumomo.cpp
@@ -32,6 +32,8 @@ struct SumomoConfig {
   bool hw_mjpeg_decoder = false;
   int video_bit_rate = 0;
   int audio_bit_rate = 0;
+  boost::json::value video_h264_params;
+  boost::json::value video_h265_params;
   boost::json::value metadata;
   boost::optional<bool> multistream;
   boost::optional<bool> spotlight;
@@ -136,6 +138,8 @@ class Sumomo : public std::enable_shared_from_this<Sumomo>,
     config.audio_codec_type = config_.audio_codec_type;
     config.video_bit_rate = config_.video_bit_rate;
     config.audio_bit_rate = config_.audio_bit_rate;
+    config.video_h264_params = config_.video_h264_params;
+    config.video_h265_params = config_.video_h265_params;
     config.metadata = config_.metadata;
     config.multistream = config_.multistream;
     config.spotlight = config_.spotlight;
@@ -363,6 +367,12 @@ int main(int argc, char* argv[]) {
       ->check(CLI::Range(0, 30000));
   app.add_option("--audio-bit-rate", config.audio_bit_rate, "Audio bit rate")
       ->check(CLI::Range(0, 510));
+  std::string video_h264_params;
+  app.add_option("--video-h264-params", video_h264_params,
+                 "Parameters for H.264 video codec");
+  std::string video_h265_params;
+  app.add_option("--video-h265-params", video_h265_params,
+                 "Parameters for H.265 video codec");
   std::string metadata;
   app.add_option("--metadata", metadata,
                  "Signaling metadata used in connect message")
@@ -411,6 +421,14 @@ int main(int argc, char* argv[]) {
     app.parse(argc, argv);
   } catch (const CLI::ParseError& e) {
     exit(app.exit(e));
+  }
+
+  if (!video_h264_params.empty()) {
+    config.video_h264_params = boost::json::parse(video_h264_params);
+  }
+
+  if (!video_h265_params.empty()) {
+    config.video_h265_params = boost::json::parse(video_h265_params);
   }
 
   // メタデータのパース

--- a/include/sora/sora_signaling.h
+++ b/include/sora/sora_signaling.h
@@ -79,6 +79,7 @@ struct SoraSignalingConfig {
   boost::json::value video_vp9_params;
   boost::json::value video_av1_params;
   boost::json::value video_h264_params;
+  boost::json::value video_h265_params;
   std::string audio_streaming_language_code;
   boost::json::value metadata;
   boost::json::value signaling_notify_metadata;

--- a/src/sora_signaling.cpp
+++ b/src/sora_signaling.cpp
@@ -314,6 +314,10 @@ void SoraSignaling::DoSendConnect(bool redirect) {
       m["video"].as_object()["h264_params"] = config_.video_h264_params;
     }
 
+    if (!config_.video_h265_params.is_null()) {
+      m["video"].as_object()["h265_params"] = config_.video_h265_params;
+    }
+
     // オプションの設定が行われてなければ単に true を設定
     if (m["video"].as_object().empty()) {
       m["video"] = true;


### PR DESCRIPTION
## 変更内容

検証中に必要になったので、以下のパラメーター、オプションを追加しました

- SoraSignalingConfig に video_h265_params を追加
- sumomo に --video-h264-params, --video-h265-params オプションを追加