### PR TITLE
VPL のドキュメントに誤りがあったため修正する

### DIFF
--- a/doc/vpl.md
+++ b/doc/vpl.md
@@ -26,19 +26,6 @@ https://www.intel.com/content/www/us/en/developer/tools/vpl/overview.html#gs.73u
   - Intel® Server GPU
   - 5th to 11th generation Intel Core processors using integrated graphics
 
-## NVIDIA の GPU が搭載された PC で Intel VPL を利用する方法
-
-Sora C++ SDK の 実装 (SoraVideoEncoderFactory, SoraVideoDecoderFactory クラス) では、
-NVIDIA の GPU を利用するエンコーダー/デコーダーの優先度が Intel VPL を利用するものより高くなっています。
-
-そのため、 NVIDIA の GPU が搭載された PC で Intel VPL を利用するには、以下のいずれかの対応が必要です。
-
-- NVIDIA の GPU を利用するエンコーダー/デコーダーをビルド時に無効化する ... ビルド・スクリプトで `USE_NVCODEC_ENCODER` を指定している箇所を削除する
-- NVIDIA の GPU のドライバーを削除する
-
-Sora C++ SDK をビルドしている場合は、前者の方法を推奨します。  
-また、 GPU のドライバーを削除する場合は自己責任で行ってください。
-
 ## 環境構築
 
 ### Windows


### PR DESCRIPTION
## 変更内容

- NVIDIA の GPU を利用するエンコーダー/デコーダーが Intel VPL のものより優先すると書いていましたが、誤りだったため当該セクションを削除します

## 背景

SoraVideoDecoderFactoryConfig において、 decoders の先頭にあるもほど優先度が高い
参照: https://github.com/shiguredo/sora-cpp-sdk/blob/7f883941d38e3a53a98e4e6f78cc6fa3e3785161/include/sora/sora_video_decoder_factory.h#L42-L46

decoders を初期化する際、末尾ではなく先頭にデコーダーを追加していく実装になっているため、コード上では NvCodec より後にある Intel VPL の方が優先度が高い
参照: https://github.com/shiguredo/sora-cpp-sdk/blob/7f883941d38e3a53a98e4e6f78cc6fa3e3785161/src/sora_video_decoder_factory.cpp#L128-L216