### PR TITLE
build.md の --sora-dir の説明を修正

### DIFF
--- a/doc/build.md
+++ b/doc/build.md
@@ -37,4 +37,4 @@ python3 examples/sumomo/macos_arm64/run.py --sora-dir .
 ローカルでビルドした sdk のルートディレクトリを `--sora-dir` にて指定してください。
 
 > [!note]
-> `--sora-dir` を指定した際は examples 以下の `VERSION` ファイルを利用しません。
+> `--sora-dir` を指定した際は `examples/VERSION` に定義されている `SORA_CPP_SDK_VERSION` と `BOOST_VERSION` の値は利用されません。


### PR DESCRIPTION
## 変更内容

build.md の `--sora-dir` の説明を修正します
`--sora-dir` を指定した際に利用されないのは `SORA_CPP_SDK_VERSION` と `BOOST_VERSION` で、他の値は利用されるため、そのように修正しました