### PR TITLE
sdl_sample は sora labo / sora cloud に接続できるため記載を見直し

### DIFF
--- a/examples/sdl_sample/README.md
+++ b/examples/sdl_sample/README.md
@@ -4,10 +4,6 @@
 
 [WebRTC SFU Sora](https://sora.shiguredo.jp/) と音声や映像の送受信を行い、[SDL (Simple DirectMedia Layer)](https://www.libsdl.org/) を利用して映像を表示するサンプルです。
 
-このサンプルに [Sora Labo](https://sora-labo.shiguredo.app/) / [Sora Cloud](https://sora-cloud.shiguredo.jp/) に接続する機能を用意する予定は現在ありません。[Sumomo を使ってみる](./doc/USE_SUMOMO.md) か独自に実装していただく必要があります。
-
-- 参考記事 : [sora-cpp-sdk-samples にmomoのオプションを移植した](https://zenn.dev/tetsu_koba/articles/06e11dd4870796)
-
 ## 動作環境
 
 [動作環境](../../README.md#動作環境) をご確認ください。
@@ -20,14 +16,13 @@
 
 **ビルドに関しての問い合わせは受け付けておりません。うまくいかない場合は [GitHub Actions](https://github.com/shiguredo/sora-cpp-sdk/blob/develop/.github/workflows/build.yml) の内容をご確認ください。**
 
-
 ### リポジトリをクローンする
 
 [sora-cpp-sdk](https://github.com/shiguredo/sora-cpp-sdk) をクローンして、examples 以下のディレクトリを利用してください。
 
 ```shell
-$ git clone https://github.com/shiguredo/sora-cpp-sdk.git
-$ cd sora-cpp-sdk/examples
+git clone https://github.com/shiguredo/sora-cpp-sdk.git
+cd sora-cpp-sdk/examples
 ```
 
 ### SDL サンプルをビルドする
@@ -39,7 +34,7 @@ $ cd sora-cpp-sdk/examples
 以下のツールを準備してください。
 
 - [Visual Studio 2019](https://visualstudio.microsoft.com/ja/downloads/)
-    - C++ をビルドするためのコンポーネントを入れてください。
+  - C++ をビルドするためのコンポーネントを入れてください。
 - Python 3.10.5
 
 ##### ビルド
@@ -66,7 +61,7 @@ $ cd sora-cpp-sdk/examples
 ##### ビルド
 
 ```shell
-$ python3 sdl_sample/macos_arm64/run.py
+python3 sdl_sample/macos_arm64/run.py
 ```
 
 成功した場合、`_build/macos_arm64/release/sdl_sample` に `sdl_sample` が作成されます。
@@ -83,18 +78,18 @@ _build/macos_arm64/release/sdl_sample
 必要なパッケージをインストールしてください。
 
 ```shell
-$ sudo apt install libxext-dev
-$ sudo apt install libx11-dev
-$ sudo apt install libdrm-dev
-$ sudo apt install libva-dev
-$ sudo apt install pkg-config
-$ sudo apt install python3
+sudo apt install libxext-dev
+sudo apt install libx11-dev
+sudo apt install libdrm-dev
+sudo apt install libva-dev
+sudo apt install pkg-config
+sudo apt install python3
 ```
 
 ##### ビルド
 
 ```shell
-$ python3 sdl_sample/ubuntu-20.04_x86_64/run.py
+python3 sdl_sample/ubuntu-20.04_x86_64/run.py
 ```
 
 成功した場合、`_build/ubuntu-20.04_x86_64/release/sdl_sample` に `sdl_sample` が作成されます。
@@ -111,18 +106,18 @@ _build/ubuntu-20.04_x86_64/release/sdl_sample/
 必要なパッケージをインストールしてください。
 
 ```shell
-$ sudo apt install libxext-dev
-$ sudo apt install libx11-dev
-$ sudo apt install libdrm-dev
-$ sudo apt install libva-dev
-$ sudo apt install pkg-config
-$ sudo apt install python3
+sudo apt install libxext-dev
+sudo apt install libx11-dev
+sudo apt install libdrm-dev
+sudo apt install libva-dev
+sudo apt install pkg-config
+sudo apt install python3
 ```
 
 ##### ビルド
 
 ```shell
-$ python3 sdl_sample/ubuntu-22.04_x86_64/run.py
+python3 sdl_sample/ubuntu-22.04_x86_64/run.py
 ```
 
 成功した場合、以下のファイルが作成されます。`_build/ubuntu-22.04_x86_64/release/sdl_sample` に `sdl_sample` が作成されます。
@@ -141,21 +136,21 @@ _build/ubuntu-22.04_x86_64/release/sdl_sample/
 必要なパッケージをインストールしてください。
 
 ```shell
-$ sudo apt install multistrap
-$ sudo apt install binutils-aarch64-linux-gnu
-$ sudo apt install python3
+sudo apt install multistrap
+sudo apt install binutils-aarch64-linux-gnu
+sudo apt install python3
 ```
 
 multistrap に insecure なリポジトリからの取得を許可する設定を行います。
 
 ```shell
-$ sudo sed -e 's/Apt::Get::AllowUnauthenticated=true/Apt::Get::AllowUnauthenticated=true";\n$config_str .= " -o Acquire::AllowInsecureRepositories=true/' -i /usr/sbin/multistrap
+sudo sed -e 's/Apt::Get::AllowUnauthenticated=true/Apt::Get::AllowUnauthenticated=true";\n$config_str .= " -o Acquire::AllowInsecureRepositories=true/' -i /usr/sbin/multistrap
 ```
 
 ##### ビルド
 
 ```shell
-$ python3 sdl_sample/ubuntu-20.04_armv8_jetson/run.py
+python3 sdl_sample/ubuntu-20.04_armv8_jetson/run.py
 ```
 
 成功した場合、以下のファイルが作成されます。`_build/ubuntu-20.04_armv8_jetson/release/sdl_sample` に `sdl_sample` が作成されます。
@@ -173,13 +168,15 @@ _build/ubuntu-20.04_armv8_jetson/release/sdl_sample/
 以下は Sora サーバのシグナリング URL `wss://sora.example.com/signaling` の `sora` チャンネルに `sendrecv` で接続する例です。
 
 Windows の場合
+
 ```powershell
 > .\sdl_sample.exe --signaling-url wss://sora.example.com/signaling --role sendrecv --channel-id sora --multistream true
 ```
 
 Windows 以外の場合
+
 ```shell
-$ ./sdl_sample --signaling-url wss://sora.example.com/signaling --role sendrecv --channel-id sora --multistream true
+./sdl_sample --signaling-url wss://sora.example.com/signaling --role sendrecv --channel-id sora --multistream true
 ```
 
 #### 必須オプション
@@ -187,41 +184,41 @@ $ ./sdl_sample --signaling-url wss://sora.example.com/signaling --role sendrecv 
 - `--signaling-url` : Sora サーバのシグナリング URL (必須)
 - `--channel-id` : [channel_id](https://sora-doc.shiguredo.jp/SIGNALING#ee30e9) (必須)
 - `--role` : [role](https://sora-doc.shiguredo.jp/SIGNALING#6d21b9) (必須)
-    - sendrecv / sendonly / recvonly のいずれかを指定
+  - sendrecv / sendonly / recvonly のいずれかを指定
 
 #### SDL サンプル実行に関するオプション
 
 - `--log-level` : 実行時にターミナルに出力するログのレベル
-    - `verbose->0,info->1,warning->2,error->3,none->4` の値が指定可能です
+  - `verbose->0,info->1,warning->2,error->3,none->4` の値が指定可能です
 
 #### Sora に関するオプション
 
 設定内容については [Sora のドキュメント](https://sora-doc.shiguredo.jp/SIGNALING) も参考にしてください。
 
 - `--video-codec-type` : [ビデオコーデック指定](https://sora-doc.shiguredo.jp/SIGNALING#d47f4d)
-    - VP8 / VP9 / AV1 / H264 / H265 が指定可能ですが利用可能なコーデックはプラットフォームに依存します
-    - 未指定の場合は Sora のデフォルトである VP9 が利用されます
+  - VP8 / VP9 / AV1 / H264 / H265 が指定可能ですが利用可能なコーデックはプラットフォームに依存します
+  - 未指定の場合は Sora のデフォルトである VP9 が利用されます
 - `--multistream` : [マルチストリーム](https://sora-doc.shiguredo.jp/SIGNALING#808bc2) 機能の利用 (true/false)
-    - 未指定の場合は Sora の設定 (デフォルト: true) が設定されます
+  - 未指定の場合は Sora の設定 (デフォルト: true) が設定されます
 - `--video` : 映像の利用 (true/false)
-    - 未指定の場合は true が設定されます
+  - 未指定の場合は true が設定されます
 - `--audio` : 音声の利用 (true/false)
-    - 未指定の場合は true が設定されます
+  - 未指定の場合は true が設定されます
 - `--metadata` : [メタデータ](https://sora-doc.shiguredo.jp/SIGNALING#414142)
-    - JSON 形式の文字列を指定してください
+  - JSON 形式の文字列を指定してください
 
 #### SDL に関するオプション
 
 - `--width`
-    - 映像を表示するウインドウの横幅を指定します
+  - 映像を表示するウインドウの横幅を指定します
 - `--height`
-    - 映像を表示するウインドウの縦幅を指定します
+  - 映像を表示するウインドウの縦幅を指定します
 - `--fullscreen`
-    - 映像を表示するウインドウをフルスクリーンにします
+  - 映像を表示するウインドウをフルスクリーンにします
 - `--show-me`
-    - 送信している自分の映像を表示します
+  - 送信している自分の映像を表示します
 
 #### その他のオプション
 
 - `--help`
-    - ヘルプを表示します
+  - ヘルプを表示します


### PR DESCRIPTION
This pull request includes changes to the `examples/sdl_sample/README.md` file. The changes primarily involve removing unnecessary prefixes from command lines and removing some content that is no longer relevant.

Here are the most important changes:

* Removed the reference to the plan of connecting to [Sora Labo](https://sora-labo.shiguredo.app/) / [Sora Cloud](https://sora-cloud.shiguredo.jp/) and the related article link.
* Removed the ` prefix from command lines throughout the document to simplify copy-pasting of commands. This change is reflected in multiple places such as cloning the repository [[1]](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L23-R25) running python scripts [[2]](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L69-R64) [[3]](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L86-R92) [[4]](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L114-R120) [[5]](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L144-R153) and installing packages [[6]](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L86-R92) [[7]](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L114-R120) [[8]](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L144-R153).
* Removed the ` prefix from the command line in the section that provides an example of connecting to the Sora server.