### PR TITLE
VPL での AV1 を未サポートとする

### DIFF
--- a/src/hwenc_vpl/vpl_video_encoder.cpp
+++ b/src/hwenc_vpl/vpl_video_encoder.cpp
@@ -676,6 +676,13 @@ bool VplVideoEncoder::IsSupported(std::shared_ptr<VplSession> session,
     return false;
   }
 
+  // FIXME(miosakuma): Intel Core Ultra 7 では IsSupported(AV1) == true となるが、
+  // 実際に使ってみると映像が送信されないため、一時的に AV1 だったら未サポートとして返す。
+  // （VPL の問題なのか使い方の問題なのかは不明）
+  if (codec == webrtc::kVideoCodecAV1) {
+    return false;
+  }
+
   auto encoder = VplVideoEncoderImpl::CreateEncoder(
       session, ToMfxCodec(codec), 1920, 1080, 30, 10, 20, false);
   bool result = encoder != nullptr;


### PR DESCRIPTION
Intel Core Ultra 7 で VPL の AV1 Encoder がサポート対象になっていたのですが実際には映像が送信されていない状態になっているため、正常に動作するようになるまでソフトウェアエンコーダーを利用するようにしたく、修正を行いました。
動作確認はできていますが、念の為問題ないかご確認いただけますか。

---
This pull request includes a change to the `VplVideoEncoder::IsSupported` method in the `src/hwenc_vpl/vpl_video_encoder.cpp` file. The change adds a condition to return false if the codec is `webrtc::kVideoCodecAV1`, due to an issue where the video does not transmit even though `IsSupported(AV1)` returns true on Intel Core Ultra 7. The root cause of the issue, whether it's a problem with VPL or the usage, is currently unclear.