### PR TITLE
ドキュメントの見直し

### DIFF
--- a/doc/faq.md
+++ b/doc/faq.md
@@ -17,7 +17,7 @@ GitHub Actions でビルドを行い確認していますので、まずは GitH
 GitHub Actions のビルドが失敗していたり、
 ビルド済みバイナリがうまく動作しない場合は Discord へご連絡ください。
 
-## NVIDIA Jetson Orin (Ubuntu 20.04 arm64) でビルドできません
+## NVIDIA Jetson Orin (Ubuntu 22.04 arm64) でビルドできません
 
 Ubuntu 20.04 x86_64 でクロスコンパイルしたバイナリを利用するようにしてください。
 

--- a/examples/messaging_recvonly_sample/README.md
+++ b/examples/messaging_recvonly_sample/README.md
@@ -37,7 +37,7 @@ cd sora-cpp-sdk/examples
 
 以下のツールを準備してください。
 
-- [Visual Studio 2019](https://visualstudio.microsoft.com/ja/downloads/)
+- [Visual Studio 2022](https://visualstudio.microsoft.com/ja/downloads/)
   - C++ をビルドするためのコンポーネントを入れてください。
 - Python 3.10.5
 

--- a/examples/messaging_recvonly_sample/README.md
+++ b/examples/messaging_recvonly_sample/README.md
@@ -60,7 +60,7 @@ cd sora-cpp-sdk/examples
 
 以下のツールを準備してください。
 
-- Python 3.9.13
+- Python 3.12.4
 
 ##### ビルド
 

--- a/examples/sdl_sample/README.md
+++ b/examples/sdl_sample/README.md
@@ -37,7 +37,7 @@ cd sora-cpp-sdk/examples
 
 以下のツールを準備してください。
 
-- [Visual Studio 2019](https://visualstudio.microsoft.com/ja/downloads/)
+- [Visual Studio 2022](https://visualstudio.microsoft.com/ja/downloads/)
   - C++ をビルドするためのコンポーネントを入れてください。
 - Python 3.10.5
 

--- a/examples/sdl_sample/README.md
+++ b/examples/sdl_sample/README.md
@@ -60,7 +60,7 @@ cd sora-cpp-sdk/examples
 
 以下のツールを準備してください。
 
-- Python 3.9.13
+- Python 3.12.4
 
 ##### ビルド
 

--- a/examples/sumomo/README.md
+++ b/examples/sumomo/README.md
@@ -37,7 +37,7 @@ cd sora-cpp-sdk/examples
 
 以下のツールを準備してください。
 
-- [Visual Studio 2019](https://visualstudio.microsoft.com/ja/downloads/)
+- [Visual Studio 2022](https://visualstudio.microsoft.com/ja/downloads/)
   - C++ をビルドするためのコンポーネントを入れてください。
 - Python 3.10.5
 

--- a/examples/sumomo/README.md
+++ b/examples/sumomo/README.md
@@ -60,7 +60,7 @@ cd sora-cpp-sdk/examples
 
 以下のツールを準備してください。
 
-- Python 3.9.13
+- Python 3.12.4
 
 ##### ビルド
 

--- a/examples/sumomo/README.md
+++ b/examples/sumomo/README.md
@@ -157,7 +157,7 @@ Windows 以外の場合
 - `--role` : [role](https://sora-doc.shiguredo.jp/SIGNALING#6d21b9) (必須)
   - sendrecv / sendonly / recvonly のいずれかを指定
 
-#### Momo Sample 実行に関するオプション
+#### Sumomo 実行に関するオプション
 
 - `--log-level` : 実行時にターミナルに出力するログのレベル
   - `verbose->0,info->1,warning->2,error->3,none->4` の値が指定可能です
@@ -167,6 +167,10 @@ Windows 以外の場合
 - `--hw-mjpeg-decoder` : HW MJPEG デコーダーの利用 (true/false)
   - 未指定の場合は false が設定されます
   - NVIDIA Jetson のみで利用できます
+- `--use-hardware-encoder` : ハードウェアエンコーダーの利用 (true/false)
+- `--openh264` : openh264 ライブラリのパスをフルパスで指定します
+  - デコードには対応していません
+
 
 #### Sora に関するオプション
 
@@ -186,6 +190,8 @@ Windows 以外の場合
 - `--video-bit-rate` : [ビデオビットレート指定](https://sora-doc.shiguredo.jp/SIGNALING#5667cf)
   - 0 - 30000 の値が指定可能です
   - 0 は未指定と見なされます
+- `--video-h264-params` : [ビデオの H.264 設定指定](https://sora-doc.shiguredo.jp/SIGNALING#ffc4cb)
+- `--video-h265-params` : [ビデオの H.265 設定指定](https://sora-doc.shiguredo.jp/SIGNALING#bfe45b)
 - `--audio-bit-rate` : [オーディオビットレート指定](https://sora-doc.shiguredo.jp/SIGNALING#414142)
   - 0 - 510 の値が指定可能です
   - 0 は未指定と見なされます


### PR DESCRIPTION
ドキュメントの見直しを行い修正が必要と思われる箇所を見直しました。

- faq.md
  - Jetson Orin ののバージョンを変更しています。build.yml を確認して Ubuntu 20.04 ででビルドしていることを確認済みです
  - JetPack 5.1 の不具合についての記載を消すか悩みましたが、情報提供の意味で残しました。
- example のビルドについて
  - VisualStudio は 2022 になったので更新しています
  - Mac ビルドの Python version を 3.12.4 に変更しています。これは Github Actions で動作している Python のバージョンです
    - https://github.com/actions/runner-images/blob/main/images/macos/macos-14-Readme.md#macos-14
- sumomo の実行オプションを CHANGES を元に追加しています

---

This pull request includes updates to documentation and sample project setup instructions to reflect the latest software versions and additional options. The most important changes include updates to the required software versions and new configuration options for the `sumomo` example.

### Documentation Updates:

* Updated the NVIDIA Jetson Orin build instructions to reflect Ubuntu 22.04 instead of 20.04 in `doc/faq.md`.

### Sample Project Setup Instructions:

* Updated the `Visual Studio` version from 2019 to 2022 in the `examples/messaging_recvonly_sample/README.md`, `examples/sdl_sample/README.md`, and `examples/sumomo/README.md` files. [[1]](diffhunk://#diff-2c9cd21bb3d0448f7db36430f0af831168fa31fc4808bf80bbf07cd4bbc3198eL40-R40) [[2]](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L40-R40) [[3]](diffhunk://#diff-69266961f03c6c5468fe9c75cc51875aecb5d0043558e250b2142ba3f11c0f8fL40-R40)
* Updated the `Python` version from 3.9.13 to 3.12.4 in the `examples/messaging_recvonly_sample/README.md`, `examples/sdl_sample/README.md`, and `examples/sumomo/README.md` files. [[1]](diffhunk://#diff-2c9cd21bb3d0448f7db36430f0af831168fa31fc4808bf80bbf07cd4bbc3198eL63-R63) [[2]](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L63-R63) [[3]](diffhunk://#diff-69266961f03c6c5468fe9c75cc51875aecb5d0043558e250b2142ba3f11c0f8fL63-R63)

### New Configuration Options:

* Added new options for hardware encoder usage and OpenH264 library path in the `examples/sumomo/README.md`.
* Added new options for video H.264 and H.265 parameter settings in the `examples/sumomo/README.md`.
* Corrected section title from "Momo Sample" to "Sumomo" in the `examples/sumomo/README.md`.