### PR TITLE
OnSignaling を追加します

### DIFF
--- a/include/sora/sora_signaling.h
+++ b/include/sora/sora_signaling.h
@@ -49,6 +49,7 @@ class SoraSignalingObserver {
   virtual void OnPush(std::string text) = 0;
   virtual void OnMessage(std::string label, std::string data) = 0;
   virtual void OnSwitched(std::string text) {}
+  virtual void OnSignaling(std::string text) {}
 
   virtual void OnTrack(
       rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver) = 0;


### PR DESCRIPTION
Sora とのシグナリングメッセージを出力するため SoraSignalingObserver に OnSignaling を追加します。

用途が限定的にも関わらず全体の負荷に影響するものを SoraSignalingObserver に追加するのか、別の Observer にした方が良いのではないか。と迷ったのですが、ビデオフレームを扱うライブラリのテキストメッセージを複雑化させてまで得られる負荷軽減のメリットはすくないと考えてこの形にしました。