### PR TITLE
ルート証明書を指定可能にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,8 @@
   - @tnoho
 - [ADD] Intel VPL で AV1 エンコーダを動くようにする
   - @tnoho
+- [ADD] ルート証明書を指定可能にする
+  - @melpon
 
 ### misc
 

--- a/include/sora/rtc_ssl_verifier.h
+++ b/include/sora/rtc_ssl_verifier.h
@@ -1,6 +1,9 @@
 #ifndef RTC_SSL_VERIFIER
 #define RTC_SSL_VERIFIER
 
+#include <optional>
+#include <string>
+
 // WebRTC
 #include <rtc_base/ssl_certificate.h>
 
@@ -8,11 +11,12 @@ namespace sora {
 
 class RTCSSLVerifier : public rtc::SSLCertificateVerifier {
  public:
-  RTCSSLVerifier(bool insecure);
+  RTCSSLVerifier(bool insecure, std::optional<std::string> ca_cert);
   bool Verify(const rtc::SSLCertificate& certificate) override;
 
  private:
   bool insecure_;
+  std::optional<std::string> ca_cert_;
 };
 
 }  // namespace sora

--- a/include/sora/sora_signaling.h
+++ b/include/sora/sora_signaling.h
@@ -135,6 +135,7 @@ struct SoraSignalingConfig {
 
   std::string client_cert;
   std::string client_key;
+  std::optional<std::string> ca_cert;
 
   int websocket_close_timeout = 3;
   int websocket_connection_timeout = 30;

--- a/include/sora/ssl_verifier.h
+++ b/include/sora/ssl_verifier.h
@@ -1,6 +1,7 @@
 #ifndef SORA_SSL_VERIFIER_H_
 #define SORA_SSL_VERIFIER_H_
 
+#include <optional>
 #include <string>
 
 // openssl
@@ -11,7 +12,9 @@ namespace sora {
 // 自前で SSL の証明書検証を行うためのクラス
 class SSLVerifier {
  public:
-  static bool VerifyX509(X509* x509, STACK_OF(X509) * chain);
+  static bool VerifyX509(X509* x509,
+                         STACK_OF(X509) * chain,
+                         const std::optional<std::string>& ca_cert);
 
  private:
   // PEM 形式のルート証明書を追加する
@@ -20,6 +23,6 @@ class SSLVerifier {
   static bool LoadBuiltinSSLRootCertificates(X509_STORE* store);
 };
 
-}
+}  // namespace sora
 
 #endif

--- a/include/sora/websocket.h
+++ b/include/sora/websocket.h
@@ -3,6 +3,7 @@
 
 #include <functional>
 #include <memory>
+#include <optional>
 
 // Boost
 #include <boost/asio/io_context.hpp>
@@ -52,13 +53,15 @@ class Websocket {
             boost::asio::io_context& ioc,
             bool insecure,
             const std::string& client_cert,
-            const std::string& client_key);
+            const std::string& client_key,
+            const std::optional<std::string>& ca_cert);
   // HTTP Proxy + SSL
   Websocket(https_proxy_tag,
             boost::asio::io_context& ioc,
             bool insecure,
             const std::string& client_cert,
             const std::string& client_key,
+            const std::optional<std::string>& ca_cert,
             std::string proxy_url,
             std::string proxy_username,
             std::string proxy_password);
@@ -89,7 +92,9 @@ class Websocket {
 
  private:
   bool IsSSL() const;
-  void InitWss(ssl_websocket_t* wss, bool insecure);
+  void InitWss(ssl_websocket_t* wss,
+               bool insecure,
+               const std::optional<std::string>& ca_cert);
 
   void OnResolve(std::string host,
                  std::string port,
@@ -161,6 +166,8 @@ class Websocket {
       boost::beast::http::response_parser<boost::beast::http::empty_body>>
       proxy_resp_parser_;
   boost::beast::flat_buffer proxy_buffer_;
+
+  std::optional<std::string> ca_cert_;
 };
 
 }  // namespace sora

--- a/src/rtc_ssl_verifier.cpp
+++ b/src/rtc_ssl_verifier.cpp
@@ -7,7 +7,9 @@
 
 namespace sora {
 
-RTCSSLVerifier::RTCSSLVerifier(bool insecure) : insecure_(insecure) {}
+RTCSSLVerifier::RTCSSLVerifier(bool insecure,
+                               std::optional<std::string> ca_cert)
+    : insecure_(insecure), ca_cert_(ca_cert) {}
 
 bool RTCSSLVerifier::Verify(const rtc::SSLCertificate& certificate) {
   // insecure の場合は証明書をチェックしない
@@ -17,7 +19,7 @@ bool RTCSSLVerifier::Verify(const rtc::SSLCertificate& certificate) {
   SSL* ssl = static_cast<const rtc::BoringSSLCertificate&>(certificate).ssl();
   X509* x509 = SSL_get_peer_certificate(ssl);
   STACK_OF(X509)* chain = SSL_get_peer_cert_chain(ssl);
-  return SSLVerifier::VerifyX509(x509, chain);
+  return SSLVerifier::VerifyX509(x509, chain, ca_cert_);
 }
 
-}
+}  // namespace sora

--- a/src/sora_signaling.cpp
+++ b/src/sora_signaling.cpp
@@ -171,13 +171,14 @@ void SoraSignaling::Redirect(std::string url) {
           ws.reset(
               new Websocket(Websocket::ssl_tag(), *self->config_.io_context,
                             self->config_.insecure, self->config_.client_cert,
-                            self->config_.client_key));
+                            self->config_.client_key, self->config_.ca_cert));
         } else {
           ws.reset(new Websocket(
               Websocket::https_proxy_tag(), *self->config_.io_context,
               self->config_.insecure, self->config_.client_cert,
-              self->config_.client_key, self->config_.proxy_url,
-              self->config_.proxy_username, self->config_.proxy_password));
+              self->config_.client_key, self->config_.ca_cert,
+              self->config_.proxy_url, self->config_.proxy_username,
+              self->config_.proxy_password));
         }
       } else {
         ws.reset(new Websocket(*self->config_.io_context));
@@ -509,7 +510,7 @@ SoraSignaling::CreatePeerConnection(boost::json::value jconfig) {
   //
   // それを解消するために tls_cert_verifier を設定して自前で検証を行う。
   dependencies.tls_cert_verifier = std::unique_ptr<rtc::SSLCertificateVerifier>(
-      new RTCSSLVerifier(config_.insecure));
+      new RTCSSLVerifier(config_.insecure, config_.ca_cert));
 
   // Proxy を設定する
   if (!config_.proxy_url.empty() && config_.network_manager != nullptr &&
@@ -1192,12 +1193,12 @@ void SoraSignaling::DoConnect() {
       if (config_.proxy_url.empty()) {
         ws.reset(new Websocket(Websocket::ssl_tag(), *config_.io_context,
                                config_.insecure, config_.client_cert,
-                               config_.client_key));
+                               config_.client_key, config_.ca_cert));
       } else {
         ws.reset(new Websocket(
             Websocket::https_proxy_tag(), *config_.io_context, config_.insecure,
-            config_.client_cert, config_.client_key, config_.proxy_url,
-            config_.proxy_username, config_.proxy_password));
+            config_.client_cert, config_.client_key, config_.ca_cert,
+            config_.proxy_url, config_.proxy_username, config_.proxy_password));
       }
     } else {
       ws.reset(new Websocket(*config_.io_context));


### PR DESCRIPTION
TLS 接続時に利用するルート証明書を指定できるようにしました。
ついでに sumomo に `--insecure`, `--client-cert`, `--client-key`, `--ca-cert` オプションも追加してます。