### PR TITLE
OnWsClose を SoraSignalingObserver に追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -34,6 +34,8 @@
   - @melpon
 - [ADD] VERSION と examples/VERSION のバージョンをチェックする仕組みを追加
   - @melpon
+- [ADD] WebSocket の Close を取得できるよう SendOnWsClose を SoraSignalingObserver に追加する
+  - @tnoho
 - [FIX] HTTP Proxy 利用時の Websocket 初期化で insecure_ メンバ変数が初期化されていなかったのを修正
   - @melpon
 

--- a/include/sora/sora_signaling.h
+++ b/include/sora/sora_signaling.h
@@ -227,7 +227,7 @@ class SoraSignaling : public std::enable_shared_from_this<SoraSignaling>,
   void SendOnSignalingMessage(SoraSignalingType type,
                               SoraSignalingDirection direction,
                               std::string message);
-  void SendOnWsClose(boost::beast::websocket::close_reason& reason);
+  void SendOnWsClose(const boost::beast::websocket::close_reason& reason);
 
   webrtc::DataBuffer ConvertToDataBuffer(const std::string& label,
                                          const std::string& input);

--- a/include/sora/sora_signaling.h
+++ b/include/sora/sora_signaling.h
@@ -62,6 +62,7 @@ class SoraSignalingObserver {
   virtual void OnSignalingMessage(SoraSignalingType type,
                                   SoraSignalingDirection direction,
                                   std::string message) {}
+  virtual void OnWsClose(uint16_t code, std::string message) {}
 
   virtual void OnTrack(
       rtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver) = 0;
@@ -226,6 +227,7 @@ class SoraSignaling : public std::enable_shared_from_this<SoraSignaling>,
   void SendOnSignalingMessage(SoraSignalingType type,
                               SoraSignalingDirection direction,
                               std::string message);
+  void SendOnWsClose(boost::beast::websocket::close_reason& reason);
 
   webrtc::DataBuffer ConvertToDataBuffer(const std::string& label,
                                          const std::string& input);

--- a/src/sora_signaling.cpp
+++ b/src/sora_signaling.cpp
@@ -591,6 +591,7 @@ void SoraSignaling::DoInternalDisconnect(
       boost::system::error_code tec;
       self->closing_timeout_timer_.cancel(tec);
       auto ws_reason = self->ws_->reason();
+      self->SendOnWsClose(ws_reason);
       std::string message =
           "Unintended disconnect WebSocket during Disconnect process: ec=" +
           ec.message() + " wscode=" + std::to_string(ws_reason.code) +
@@ -624,6 +625,7 @@ void SoraSignaling::DoInternalDisconnect(
             boost::system::error_code tec;
             self->closing_timeout_timer_.cancel(tec);
             auto ws_reason = self->ws_->reason();
+            self->SendOnWsClose(ws_reason);
             std::string ws_reason_str =
                 " wscode=" + std::to_string(ws_reason.code) +
                 " wsreason=" + ws_reason.reason.c_str();
@@ -705,6 +707,7 @@ void SoraSignaling::DoInternalDisconnect(
             bool ec_error = ec != boost::beast::websocket::error::closed;
             if (ec_error) {
               auto reason = self->ws_->reason();
+              self->SendOnWsClose(reason);
               on_close(false, SoraSignalingErrorCode::CLOSE_FAILED,
                        "Failed to close WebSocket: ec=" + ec.message() +
                            " wscode=" + std::to_string(reason.code) +
@@ -816,6 +819,7 @@ void SoraSignaling::OnRead(boost::system::error_code ec,
                             ? SoraSignalingErrorCode::WEBSOCKET_ONCLOSE
                             : SoraSignalingErrorCode::WEBSOCKET_ONERROR;
       auto reason = ws_->reason();
+      SendOnWsClose(reason);
       std::string reason_str = " wscode=" + std::to_string(reason.code) +
                                " wsreason=" + reason.reason.c_str();
       SendOnDisconnect(error_code, "Failed to read WebSocket: ec=" +
@@ -1352,6 +1356,13 @@ void SoraSignaling::SendOnSignalingMessage(SoraSignalingType type,
                                            std::string message) {
   if (auto ob = config_.observer.lock(); ob) {
     ob->OnSignalingMessage(type, direction, std::move(message));
+  }
+}
+
+void SoraSignaling::SendOnWsClose(
+    boost::beast::websocket::close_reason& reason) {
+  if (auto ob = config_.observer.lock(); ob) {
+    ob->OnWsClose(reason.code, std::string(reason.reason.c_str()));
   }
 }
 

--- a/src/sora_signaling.cpp
+++ b/src/sora_signaling.cpp
@@ -704,10 +704,10 @@ void SoraSignaling::DoInternalDisconnect(
           self->on_ws_close_ = [self, on_close](boost::system::error_code ec) {
             boost::system::error_code tec;
             self->closing_timeout_timer_.cancel(tec);
+            auto reason = self->ws_->reason();
+            self->SendOnWsClose(reason);
             bool ec_error = ec != boost::beast::websocket::error::closed;
             if (ec_error) {
-              auto reason = self->ws_->reason();
-              self->SendOnWsClose(reason);
               on_close(false, SoraSignalingErrorCode::CLOSE_FAILED,
                        "Failed to close WebSocket: ec=" + ec.message() +
                            " wscode=" + std::to_string(reason.code) +
@@ -1360,9 +1360,9 @@ void SoraSignaling::SendOnSignalingMessage(SoraSignalingType type,
 }
 
 void SoraSignaling::SendOnWsClose(
-    boost::beast::websocket::close_reason& reason) {
+    const boost::beast::websocket::close_reason& reason) {
   if (auto ob = config_.observer.lock(); ob) {
-    ob->OnWsClose(reason.code, std::string(reason.reason.c_str()));
+    ob->OnWsClose(reason.code, reason.reason.c_str());
   }
 }
 


### PR DESCRIPTION
WebSocket が閉じられた時の code と reason を取得できるよう OnWsClose を SoraSignalingObserver に追加します