### PR TITLE
Intel VPL の利用方法を更新

### DIFF
--- a/doc/vpl.md
+++ b/doc/vpl.md
@@ -40,9 +40,7 @@ Windows 11 では Intel の公式サイトからドライバーをインスト�
 
 ### Ubuntu 22.04
 
-#### Intel VPL ランタイムをインストールする
-
-##### Intel の apt リポジトリを追加
+#### Intel の apt リポジトリを追加
 
 ランタイムのインストールには Intel の apt リポジトリを追加する必要があります。
 
@@ -54,7 +52,7 @@ echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] htt
 sudo apt update
 ```
 
-##### Intel 提供パッケージの最新化
+#### Intel 提供パッケージの最新化
 
 Intel の apt リポジトリを追加することでインストール済みのパッケージも Intel から提供されている最新のものに更新できます。依存問題を起こさないため、ここで最新化を行なってください。
 
@@ -62,7 +60,7 @@ Intel の apt リポジトリを追加することでインストール済みの
 sudo apt upgrade
 ```
 
-##### ドライバとライブラリのインストール
+#### ドライバとライブラリのインストール
 
 以下のように、ドライバとライブラリをインストールしてください。
 intel-media-va-driver には無印と `non-free` 版がありますが、 `non-free` 版でしか動作しません。
@@ -75,9 +73,7 @@ sudo apt install -y intel-media-va-driver-non-free libmfxgen1
 
 デコードのみであれば標準のリポジトリからも libmfx-gen1.2 をインストール可能ですが、エンコードも行いたいため Intel の apt リポジトリより libmfxgen1 をインストールします。
 
-#### Intel VPL ランタイムをインストールする
-
-##### Intel の apt リポジトリを追加
+#### Intel の apt リポジトリを追加
 
 ランタイムのインストールには Intel の apt リポジトリを追加する必要があります。
 
@@ -90,7 +86,7 @@ echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] htt
 sudo apt update
 ```
 
-##### ライブラリのインストール
+#### ライブラリのインストール
 
 以下の実行例のように、 libmfxgen1 をインストールしてください。
 
@@ -98,17 +94,13 @@ sudo apt update
 sudo apt install -y libmfxgen1
 ```
 
-##### 再起動
-
-パッケージのインストールが完了したら、再起動してください。
-
-#### Intel Media SDK を利用する手順
+### Intel Media SDK を利用する手順
 
 Intel のチップセットの世代によって、 Intel Media SDK を利用する必要がある場合があります。
 
 以下の手順で Intel Media SDK をインストールしてください。
 
-##### Intel の apt リポジトリを追加
+#### Intel の apt リポジトリを追加
 
 ```bash
 wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
@@ -118,7 +110,7 @@ echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] htt
 sudo apt update
 ```
 
-###### パッケージのインストール
+##### パッケージのインストール
 
 ```bash
 sudo apt install -y \
@@ -129,10 +121,16 @@ sudo apt install -y \
   mesa-vdpau-drivers mesa-vulkan-drivers va-driver-all vainfo hwinfo clinfo
 ```
 
-### Ubuntu 22.04 で環境構築ができたことを確認する手順
+## Ubuntu 22.04 で環境構築ができたことを確認する手順
 
 `vainfo` コマンドを実行します。  
 エラーが発生しなければ、 Intel VPL の実行に必要なドライバーやライブラリのインストールに成功しています。
+
+`vainfo` がインストールされていない場合は、下記のコマンドで `vainfo` をインストールします。
+
+```bash
+sudo apt install -y vainfo
+```
 
 以下は `vainfo` を実行した出力の例です。  
 対応しているプロファイルやエントリーポイントは環境によって異なります。

--- a/doc/vpl.md
+++ b/doc/vpl.md
@@ -40,9 +40,6 @@ Windows 11 では Intel の公式サイトからドライバーをインスト�
 
 ### Ubuntu 22.04
 
-Ubuntu 22.04 で Intel VPL を利用するためには、ドライバーとライブラリをインストールする必要があります。
-公式ドキュメントの <https://dgpu-docs.intel.com/driver/client/overview.html> を参考に必要なドライバーとライブラリをインストールします。
-
 #### Intel VPL ランタイムをインストールする
 
 ##### Intel の apt リポジトリを追加
@@ -60,14 +57,12 @@ sudo apt update
 
 ##### パッケージのインストール
 
-公式ドキュメントでは libmfxgen1 をインストールする手順が記載されていますが、Intel VPL ランタイムを使用するには libmfx-gen1.2 が必要です。
-
-以下の実行例のように、 libmfx-gen1.2 をインストールしてください。
+以下のように、パッケージをインストールしてください。
 
 ```bash
 sudo apt install -y \
   intel-opencl-icd intel-level-zero-gpu level-zero \
-  intel-media-va-driver-non-free libmfx1 libmfx-gen1.2 libvpl2 \
+  intel-media-va-driver-non-free libmfx1 libmfxgen1 libvpl2 \
   libegl-mesa0 libegl1-mesa libegl1-mesa-dev libgbm1 libgl1-mesa-dev libgl1-mesa-dri \
   libglapi-mesa libgles2-mesa-dev libglx-mesa0 libigdgmm12 libxatracker2 mesa-va-drivers \
   mesa-vdpau-drivers mesa-vulkan-drivers va-driver-all vainfo hwinfo clinfo
@@ -75,7 +70,6 @@ sudo apt install -y \
 
 ### Ubuntu 24.04
 
-Ubuntu 24.04 で Intel VPL を利用するためには、ライブラリをインストールする必要があります。
 デコードのみであれば標準のリポジトリからも libmfx-gen1.2 をインストール可能ですが、エンコードも行いたいため Intel の apt リポジトリより libmfxgen1 をインストールします。
 
 #### Intel VPL ランタイムをインストールする

--- a/doc/vpl.md
+++ b/doc/vpl.md
@@ -44,10 +44,9 @@ Windows 11 では Intel の公式サイトからドライバーをインスト�
 
 ##### Intel の apt リポジトリを追加
 
-パッケージのインストールには Intel の apt リポジトリを追加する必要があります。
+ランタイムのインストールには Intel の apt リポジトリを追加する必要があります。
 
 ```bash
-
 wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
   sudo gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg
 echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu jammy client" | \
@@ -55,17 +54,21 @@ echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] htt
 sudo apt update
 ```
 
-##### パッケージのインストール
+##### Intel 提供パッケージの最新化
 
-以下のように、パッケージをインストールしてください。
+Intel の apt リポジトリを追加することでインストール済みのパッケージも Intel から提供されている最新のものに更新できます。依存問題を起こさないため、ここで最新化を行なってください。
 
 ```bash
-sudo apt install -y \
-  intel-opencl-icd intel-level-zero-gpu level-zero \
-  intel-media-va-driver-non-free libmfx1 libmfxgen1 libvpl2 \
-  libegl-mesa0 libegl1-mesa libegl1-mesa-dev libgbm1 libgl1-mesa-dev libgl1-mesa-dri \
-  libglapi-mesa libgles2-mesa-dev libglx-mesa0 libigdgmm12 libxatracker2 mesa-va-drivers \
-  mesa-vdpau-drivers mesa-vulkan-drivers va-driver-all vainfo hwinfo clinfo
+sudo apt upgrade
+```
+
+##### ドライバとライブラリのインストール
+
+以下のように、ドライバとライブラリをインストールしてください。
+intel-media-va-driver には無印と `non-free` 版がありますが、 `non-free` 版でしか動作しません。
+
+```bash
+sudo apt install -y intel-media-va-driver-non-free libmfxgen1
 ```
 
 ### Ubuntu 24.04
@@ -76,7 +79,7 @@ sudo apt install -y \
 
 ##### Intel の apt リポジトリを追加
 
-パッケージのインストールには Intel の apt リポジトリを追加する必要があります。
+ランタイムのインストールには Intel の apt リポジトリを追加する必要があります。
 
 ```bash
 
@@ -87,7 +90,7 @@ echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] htt
 sudo apt update
 ```
 
-##### パッケージのインストール
+##### ライブラリのインストール
 
 以下の実行例のように、 libmfxgen1 をインストールしてください。
 

--- a/doc/vpl.md
+++ b/doc/vpl.md
@@ -73,6 +73,34 @@ sudo apt install -y \
   mesa-vdpau-drivers mesa-vulkan-drivers va-driver-all vainfo hwinfo clinfo
 ```
 
+### Ubuntu 24.04
+
+Ubuntu 24.04 で Intel VPL を利用するためには、ライブラリをインストールする必要があります。
+デコードのみであれば標準のリポジトリからも libmfx-gen1.2 をインストール可能ですが、エンコードも行いたいため Intel の apt リポジトリより libmfxgen1 をインストールします。
+
+#### Intel VPL ランタイムをインストールする
+
+##### Intel の apt リポジトリを追加
+
+パッケージのインストールには Intel の apt リポジトリを追加する必要があります。
+
+```bash
+
+wget -qO - https://repositories.intel.com/gpu/intel-graphics.key | \
+  sudo gpg --dearmor --output /usr/share/keyrings/intel-graphics.gpg
+echo "deb [arch=amd64,i386 signed-by=/usr/share/keyrings/intel-graphics.gpg] https://repositories.intel.com/gpu/ubuntu noble client" | \
+  sudo tee /etc/apt/sources.list.d/intel-gpu-noble.list
+sudo apt update
+```
+
+##### パッケージのインストール
+
+以下の実行例のように、 libmfxgen1 をインストールしてください。
+
+```bash
+sudo apt install -y libmfxgen1
+```
+
 ##### 再起動
 
 パッケージのインストールが完了したら、再起動してください。


### PR DESCRIPTION
Intel VPL のインストールドキュメントが大幅に変更されており、従っても動作させることができなかったため動作検証を行った手順に Intel VPL の利用方法を更新します。