### PR TITLE
[WIP] Ubuntu24.04 で SDL が起動しない問題を解決するために libgl-dev を追加する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,6 +236,9 @@ jobs:
           # X11
           sudo apt-get install libx11-dev libxext-dev
 
+          # OpenGL
+          sudo apt-get install -y libgl-dev
+
           # CUDA
           source /etc/os-release
           # 20.04 は自前の libssl1.1 があるので不要
@@ -255,7 +258,7 @@ jobs:
       - name: Install deps for ${{ matrix.platform.name }}
         if: matrix.platform.os == 'ubuntu' && matrix.platform.arch == 'armv8'
         run: |
-          sudo apt-get -y install multistrap binutils-aarch64-linux-gnu
+          sudo apt-get -y install multistrap binutils-aarch64-linux-gnu libgl-dev
           # multistrap に insecure なリポジトリからの取得を許可する設定を入れる
           sudo sed -e 's/Apt::Get::AllowUnauthenticated=true/Apt::Get::AllowUnauthenticated=true";\n$config_str .= " -o Acquire::AllowInsecureRepositories=true/' -i /usr/sbin/multistrap
       - name: Install deps for Android

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,6 +113,11 @@
 - [ADD] VERSION と examples/VERSION のバージョンをチェックする仕組みを追加
   - @melpon
 - [ADD] SDL のために `libgl-dev` をインストールする
+  - Ubuntu 24.04 環境で SDL を使用する際、SDL の画面生成に失敗していた問題を修正
+  - 問題の原因は以下の通り
+    - ビルド時に [OPENGL を有効にしていた](https://github.com/shiguredo/sora-cpp-sdk/blob/develop/buildbase.py#L1140)ものの、OpenGL がインストールされていない環境で SDL をビルドすると、SDL の OpenGL 機能が無効化される仕様になっていたため
+    - 参考リンク : [SDL の OpenGL をチェックしている場所](https://hg.libsdl.org/SDL/file/default/README-SDL.md)
+  - この問題を解決するために、 OpenGL が有効になるように `libgl-dev` をインストールする
   - @torikizi
 
 ## 2024.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,8 @@
   - @melpon
 - [ADD] VERSION と examples/VERSION のバージョンをチェックする仕組みを追加
   - @melpon
+- [ADD] SDL のために `libgl-dev` をインストールする
+  - @torikizi
 
 ## 2024.7.0
 


### PR DESCRIPTION
SDL の依存解決のために libel-dev を追加

----

This pull request includes updates to the build configuration in `.github/workflows/build.yml` and documentation in `CHANGES.md` to support the installation of `libgl-dev` for OpenGL.

### Build configuration updates:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R239-R241): Added installation of `libgl-dev` for OpenGL support in the Ubuntu setup steps. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R239-R241) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L258-R261)

### Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R115-R116): Added an entry to document the installation of `libgl-dev` for SDL.