### PR TITLE
SDL のビルドのために `libgl-dev` のインストールを追加する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -236,6 +236,9 @@ jobs:
           # X11
           sudo apt-get install libx11-dev libxext-dev
 
+          # OpenGL
+          sudo apt-get install -y libgl-dev
+
           # CUDA
           source /etc/os-release
           # 20.04 は自前の libssl1.1 があるので不要
@@ -255,7 +258,7 @@ jobs:
       - name: Install deps for ${{ matrix.platform.name }}
         if: matrix.platform.os == 'ubuntu' && matrix.platform.arch == 'armv8'
         run: |
-          sudo apt-get -y install multistrap binutils-aarch64-linux-gnu
+          sudo apt-get -y install multistrap binutils-aarch64-linux-gnu libgl-dev
           # multistrap に insecure なリポジトリからの取得を許可する設定を入れる
           sudo sed -e 's/Apt::Get::AllowUnauthenticated=true/Apt::Get::AllowUnauthenticated=true";\n$config_str .= " -o Acquire::AllowInsecureRepositories=true/' -i /usr/sbin/multistrap
       - name: Install deps for Android

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,12 +112,10 @@
   - @melpon
 - [ADD] VERSION と examples/VERSION のバージョンをチェックする仕組みを追加
   - @melpon
-- [ADD] SDL のために `libgl-dev` をインストールする
-  - Ubuntu 24.04 環境で SDL を使用する際、SDL の画面生成に失敗していた問題を修正
-  - 問題の原因は以下の通り
-    - ビルド時に [OPENGL を有効にしていた](https://github.com/shiguredo/sora-cpp-sdk/blob/develop/buildbase.py#L1140)ものの、OpenGL がインストールされていない環境で SDL をビルドすると、SDL の OpenGL 機能が無効化される仕様になっていたため
-    - 参考リンク : [SDL の OpenGL をチェックしている場所](https://hg.libsdl.org/SDL/file/default/README-SDL.md)
-  - この問題を解決するために、 OpenGL が有効になるように `libgl-dev` をインストールする
+- [FIX] SDL のビルドのために `libgl-dev` をインストールを追加する
+  - SDL のビルド時に OpenGL がない場合、SDL の OpenGL 機能が無効化される仕様になっていたためインストールを追加
+  - OpenGL 関連の機能が無効化されると SDL の画面作成ができなくなる
+  - 参考リンク : [SDL の OpenGL をチェックしている場所](https://hg.libsdl.org/SDL/file/default/README-SDL.md)
   - @torikizi
 
 ## 2024.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,7 +113,7 @@
 - [ADD] VERSION と examples/VERSION のバージョンをチェックする仕組みを追加
   - @melpon
 - [FIX] SDL のビルドのために `libgl-dev` をインストールを追加する
-  - SDL のビルド時に OpenGL がない場合、SDL の OpenGL 機能が無効化される仕様になっていたためインストールを追加
+  - SDL のビルド時に OpenGL がない場合、OpenGL 機能が無効化される仕様になっていたためインストールを追加
   - OpenGL 関連の機能が無効化されると SDL の画面作成ができなくなる
   - 参考リンク : [SDL の OpenGL をチェックしている場所](https://hg.libsdl.org/SDL/file/default/README-SDL.md)
   - @torikizi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -114,7 +114,7 @@
   - @melpon
 - [FIX] SDL のビルドのために `libgl-dev` のインストールを追加する
   - SDL のビルド時に OpenGL がない場合、OpenGL 機能が無効化される仕様になっていたためインストールを追加
-  - OpenGL 関連の機能が無効化されると SDL の画面作成ができなくなる
+  - OpenGL の機能が無効化されると examples アプリの起動時に SDL の画面作成が失敗する
   - 参考リンク : [SDL の OpenGL をチェックしている場所](https://hg.libsdl.org/SDL/file/default/README-SDL.md)
   - @torikizi
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,7 +112,7 @@
   - @melpon
 - [ADD] VERSION と examples/VERSION のバージョンをチェックする仕組みを追加
   - @melpon
-- [FIX] SDL ビルド時に libgl-dev がない場合、examples アプリ起動時に SDL 画面作成が失敗する問題を修正するため、libgl-dev をインストールするように build.yml を修正する
+- [FIX] examples のビルド時に libgl-dev がない場合、examples アプリ起動時に SDL 画面作成が失敗する問題を修正するため、libgl-dev をインストールするように build.yml を修正する
   - SDL のビルド時に libgl-dev がない環境では、OpenGL のヘッダーファイルがないため SDL の OpenGL 機能が有効化されず、examples アプリ起動時に SDL の画面作成が失敗する
   - libgl-dev をインストールすることで OpenGL 機能が有効化され、examples アプリ起動時に SDL の画面作成が成功するようになる
   - 参考リンク : [SDL の OpenGL をチェックしている場所](https://hg.libsdl.org/SDL/file/default/README-SDL.md)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,6 +113,11 @@
 - [ADD] VERSION と examples/VERSION のバージョンをチェックする仕組みを追加
   - @melpon
 - [ADD] SDL のために `libgl-dev` をインストールする
+  - Ubuntu 24.04 環境で SDL を使用する際、SDL の画面生成に失敗していた問題を修正
+  - 問題の原因は以下の通り
+    - ビルド時に [OPENGL を有効にしていた](https://github.com/shiguredo/sora-cpp-sdk/blob/develop/buildbase.py#L1140)ものの、OpenGL がインストールされていない環境で SDL をビルドすると、SDL の OpenGL 機能が無効化される仕様になっていたため
+    - 参考リンク : [SDL の OpenGL をチェックしている場所](https://hg.libsdl.org/SDL/file/default/README-SDL.md)
+  - この問題を解決するために、 OpenGL が有効になるように `libgl-dev` をインストールする
   - @torikizi
 
 ## 2024.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -115,7 +115,7 @@
 - [FIX] examples のビルド時に libgl-dev がない場合、examples アプリ起動時に SDL 画面作成が失敗する問題を修正するため、libgl-dev をインストールするように build.yml を修正する
   - SDL のビルド時に libgl-dev がない環境では、OpenGL のヘッダーファイルがないため SDL の OpenGL 機能が有効化されず、examples アプリ起動時に SDL の画面作成が失敗する
   - libgl-dev をインストールすることで OpenGL 機能が有効化され、examples アプリ起動時に SDL の画面作成が成功するようになる
-  - 参考リンク : [SDL の OpenGL をチェックしている場所](https://hg.libsdl.org/SDL/file/default/README-SDL.md)
+  - 参考リンク : [SDL の OpenGL をチェックしている場所](https://github.com/libsdl-org/SDL/blob/2c7b7d1d33748b6c27eaf57cc5d96ce6c4c64a87/cmake/sdlchecks.cmake#L722-L733)
   - @torikizi
 
 ## 2024.7.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,9 +112,9 @@
   - @melpon
 - [ADD] VERSION と examples/VERSION のバージョンをチェックする仕組みを追加
   - @melpon
-- [FIX] SDL のビルドのために `libgl-dev` のインストールを追加する
-  - SDL のビルド時に OpenGL がない場合、OpenGL 機能が無効化される仕様になっていたためインストールを追加
-  - OpenGL の機能が無効化されると examples アプリの起動時に SDL の画面作成が失敗する
+- [FIX] SDL ビルド時に libgl-dev がない場合、examples アプリ起動時に SDL 画面作成が失敗する問題を修正するため、libgl-dev をインストールするように build.yml を修正する
+  - SDL のビルド時に libgl-dev がない環境では、OpenGL のヘッダーファイルがないため SDL の OpenGL レンダリング機能が有効化されず、examples アプリ起動時に SDL の画面作成が失敗する
+  - libgl-dev をインストールすることで OpenGL レンダリング機能が有効化され、examples アプリ起動時に SDL の画面作成が成功するようになる
   - 参考リンク : [SDL の OpenGL をチェックしている場所](https://hg.libsdl.org/SDL/file/default/README-SDL.md)
   - @torikizi
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,7 +113,7 @@
 - [ADD] VERSION と examples/VERSION のバージョンをチェックする仕組みを追加
   - @melpon
 - [FIX] examples のビルド時に libgl-dev がない場合、examples アプリ起動時に SDL 画面作成が失敗する問題を修正するため、libgl-dev をインストールするように build.yml を修正する
-  - SDL のビルド時に libgl-dev がない環境では、OpenGL のヘッダーファイルがないため SDL の OpenGL 機能が有効化されず、examples アプリ起動時に SDL の画面作成が失敗する
+  - SDL のビルド時に libgl-dev がない環境では、SDL の OpenGL 機能が有効化されず、examples アプリ起動時に SDL の画面作成が失敗する
   - libgl-dev をインストールすることで OpenGL 機能が有効化され、examples アプリ起動時に SDL の画面作成が成功するようになる
   - 参考リンク : [SDL の OpenGL をチェックしている場所](https://github.com/libsdl-org/SDL/blob/2c7b7d1d33748b6c27eaf57cc5d96ce6c4c64a87/cmake/sdlchecks.cmake#L722-L733)
   - @torikizi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -113,8 +113,8 @@
 - [ADD] VERSION と examples/VERSION のバージョンをチェックする仕組みを追加
   - @melpon
 - [FIX] SDL ビルド時に libgl-dev がない場合、examples アプリ起動時に SDL 画面作成が失敗する問題を修正するため、libgl-dev をインストールするように build.yml を修正する
-  - SDL のビルド時に libgl-dev がない環境では、OpenGL のヘッダーファイルがないため SDL の OpenGL レンダリング機能が有効化されず、examples アプリ起動時に SDL の画面作成が失敗する
-  - libgl-dev をインストールすることで OpenGL レンダリング機能が有効化され、examples アプリ起動時に SDL の画面作成が成功するようになる
+  - SDL のビルド時に libgl-dev がない環境では、OpenGL のヘッダーファイルがないため SDL の OpenGL 機能が有効化されず、examples アプリ起動時に SDL の画面作成が失敗する
+  - libgl-dev をインストールすることで OpenGL 機能が有効化され、examples アプリ起動時に SDL の画面作成が成功するようになる
   - 参考リンク : [SDL の OpenGL をチェックしている場所](https://hg.libsdl.org/SDL/file/default/README-SDL.md)
   - @torikizi
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,7 +112,7 @@
   - @melpon
 - [ADD] VERSION と examples/VERSION のバージョンをチェックする仕組みを追加
   - @melpon
-- [FIX] examples のビルド時に libgl-dev がない場合、examples アプリ起動時に SDL 画面作成が失敗する問題を修正するため、libgl-dev をインストールするように build.yml を修正する
+- [FIX] examples のビルド時に libgl-dev がない環境で SDL の画面作成が失敗する問題を解消するために、build.yml を修正して libgl-dev のインストールを追加する
   - SDL のビルド時に libgl-dev がない環境では、SDL の OpenGL 機能が有効化されず、examples アプリ起動時に SDL の画面作成が失敗する
   - libgl-dev をインストールすることで OpenGL 機能が有効化され、examples アプリ起動時に SDL の画面作成が成功するようになる
   - 参考リンク : [SDL の OpenGL をチェックしている場所](https://github.com/libsdl-org/SDL/blob/2c7b7d1d33748b6c27eaf57cc5d96ce6c4c64a87/cmake/sdlchecks.cmake#L722-L733)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,6 +112,8 @@
   - @melpon
 - [ADD] VERSION と examples/VERSION のバージョンをチェックする仕組みを追加
   - @melpon
+- [ADD] SDL のために `libgl-dev` をインストールする
+  - @torikizi
 
 ## 2024.7.0
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -112,7 +112,7 @@
   - @melpon
 - [ADD] VERSION と examples/VERSION のバージョンをチェックする仕組みを追加
   - @melpon
-- [FIX] SDL のビルドのために `libgl-dev` をインストールを追加する
+- [FIX] SDL のビルドのために `libgl-dev` のインストールを追加する
   - SDL のビルド時に OpenGL がない場合、OpenGL 機能が無効化される仕様になっていたためインストールを追加
   - OpenGL 関連の機能が無効化されると SDL の画面作成ができなくなる
   - 参考リンク : [SDL の OpenGL をチェックしている場所](https://hg.libsdl.org/SDL/file/default/README-SDL.md)

--- a/examples/messaging_recvonly_sample/README.md
+++ b/examples/messaging_recvonly_sample/README.md
@@ -82,10 +82,7 @@ _build/macos_arm64/release/messaging_recvonly_sample
 必要なパッケージをインストールしてください。
 
 ```shell
-sudo apt install build-essential
-sudo apt install libx11-dev
-sudo apt install pkg-config
-sudo apt install python3
+sudo apt install build-essential libx11-dev pkg-config python3
 ```
 
 ##### ビルド
@@ -108,10 +105,7 @@ _build/ubuntu-20.04_x86_64/release/messaging_recvonly_sample/
 必要なパッケージをインストールしてください。
 
 ```shell
-sudo apt install build-essential
-sudo apt install libx11-dev
-sudo apt install pkg-config
-sudo apt install python3
+sudo apt install build-essential libx11-dev pkg-config python3
 ```
 
 ##### ビルド
@@ -134,10 +128,7 @@ _build/ubuntu-22.04_x86_64/release/messaging_recvonly_sample/
 必要なパッケージをインストールしてください。
 
 ```shell
-sudo apt install build-essential
-sudo apt install libx11-dev
-sudo apt install pkg-config
-sudo apt install python3
+sudo apt install build-essential libx11-dev pkg-config python3
 ```
 
 ##### ビルド

--- a/examples/sdl_sample/README.md
+++ b/examples/sdl_sample/README.md
@@ -82,12 +82,7 @@ _build/macos_arm64/release/sdl_sample
 必要なパッケージをインストールしてください。
 
 ```shell
-sudo apt install build-essential
-sudo apt install libxext-dev
-sudo apt install libx11-dev
-sudo apt install libgl-dev
-sudo apt install pkg-config
-sudo apt install python3
+sudo apt install build-essential libxext-dev libx11-dev libgl-dev pkg-config python3
 ```
 
 ##### ビルド
@@ -110,12 +105,7 @@ _build/ubuntu-20.04_x86_64/release/sdl_sample/
 必要なパッケージをインストールしてください。
 
 ```shell
-sudo apt install build-essential
-sudo apt install libxext-dev
-sudo apt install libx11-dev
-sudo apt install libgl-dev
-sudo apt install pkg-config
-sudo apt install python3
+sudo apt install build-essential libxext-dev libx11-dev libgl-dev pkg-config python3
 ```
 
 ##### ビルド
@@ -138,12 +128,7 @@ _build/ubuntu-22.04_x86_64/release/sdl_sample/
 必要なパッケージをインストールしてください。
 
 ```shell
-sudo apt install build-essential
-sudo apt install libxext-dev
-sudo apt install libx11-dev
-sudo apt install libgl-dev
-sudo apt install pkg-config
-sudo apt install python3
+sudo apt install build-essential libxext-dev libx11-dev libgl-dev pkg-config python3
 ```
 
 ##### ビルド

--- a/examples/sdl_sample/README.md
+++ b/examples/sdl_sample/README.md
@@ -85,6 +85,7 @@ _build/macos_arm64/release/sdl_sample
 sudo apt install build-essential
 sudo apt install libxext-dev
 sudo apt install libx11-dev
+sudo apt install libgl-dev
 sudo apt install pkg-config
 sudo apt install python3
 ```
@@ -112,6 +113,7 @@ _build/ubuntu-20.04_x86_64/release/sdl_sample/
 sudo apt install build-essential
 sudo apt install libxext-dev
 sudo apt install libx11-dev
+sudo apt install libgl-dev
 sudo apt install pkg-config
 sudo apt install python3
 ```
@@ -139,6 +141,7 @@ _build/ubuntu-22.04_x86_64/release/sdl_sample/
 sudo apt install build-essential
 sudo apt install libxext-dev
 sudo apt install libx11-dev
+sudo apt install libgl-dev
 sudo apt install pkg-config
 sudo apt install python3
 ```

--- a/examples/sumomo/README.md
+++ b/examples/sumomo/README.md
@@ -85,6 +85,7 @@ _build/macos_arm64/release/sumomo
 sudo apt install build-essential
 sudo apt install libxext-dev
 sudo apt install libx11-dev
+sudo apt install libgl-dev
 sudo apt install pkg-config
 sudo apt install python3
 ```
@@ -112,6 +113,7 @@ _build/ubuntu-20.04_x86_64/release/sumomo/
 sudo apt install build-essential
 sudo apt install libxext-dev
 sudo apt install libx11-dev
+sudo apt install libgl-dev
 sudo apt install pkg-config
 sudo apt install python3
 ```
@@ -139,6 +141,7 @@ _build/ubuntu-22.04_x86_64/release/sumomo/
 sudo apt install build-essential
 sudo apt install libxext-dev
 sudo apt install libx11-dev
+sudo apt install libgl-dev
 sudo apt install pkg-config
 sudo apt install python3
 ```

--- a/examples/sumomo/README.md
+++ b/examples/sumomo/README.md
@@ -82,12 +82,7 @@ _build/macos_arm64/release/sumomo
 必要なパッケージをインストールしてください。
 
 ```shell
-sudo apt install build-essential
-sudo apt install libxext-dev
-sudo apt install libx11-dev
-sudo apt install libgl-dev
-sudo apt install pkg-config
-sudo apt install python3
+sudo apt install build-essential libxext-dev libx11-dev libgl-dev pkg-config python3
 ```
 
 ##### ビルド
@@ -110,12 +105,7 @@ _build/ubuntu-20.04_x86_64/release/sumomo/
 必要なパッケージをインストールしてください。
 
 ```shell
-sudo apt install build-essential
-sudo apt install libxext-dev
-sudo apt install libx11-dev
-sudo apt install libgl-dev
-sudo apt install pkg-config
-sudo apt install python3
+sudo apt install build-essential libxext-dev libx11-dev libgl-dev pkg-config python3
 ```
 
 ##### ビルド
@@ -138,12 +128,7 @@ _build/ubuntu-22.04_x86_64/release/sumomo/
 必要なパッケージをインストールしてください。
 
 ```shell
-sudo apt install build-essential
-sudo apt install libxext-dev
-sudo apt install libx11-dev
-sudo apt install libgl-dev
-sudo apt install pkg-config
-sudo apt install python3
+sudo apt install build-essential libxext-dev libx11-dev libgl-dev pkg-config python3
 ```
 
 ##### ビルド


### PR DESCRIPTION
SDL のビルド時に OpenGL がない場合、OpenGL 機能が無効化される仕様になっていたためインストールを追加


----

This pull request includes updates to the build workflow and documentation to ensure proper installation of the `libgl-dev` package, which is necessary for SDL builds.

Changes to build workflow:

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R239-R241): Added installation of `libgl-dev` package for both general and ARMv8-specific dependencies to support OpenGL in SDL builds. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R239-R241) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L258-R261)

Documentation updates:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R115-R119): Documented the addition of `libgl-dev` installation for SDL builds to prevent OpenGL-related issues during the build process.