### PR TITLE
ドキュメントに Ubuntu のデスクトップであることを明記する

### DIFF
--- a/examples/messaging_recvonly_sample/README.md
+++ b/examples/messaging_recvonly_sample/README.md
@@ -75,7 +75,7 @@ _build/macos_arm64/release/messaging_recvonly_sample
 └── messaging_recvonly_sample
 ```
 
-#### Ubuntu 20.04 x86_64 向けのビルドをする
+#### Ubuntu 20.04 x86_64 Desktop 向けのビルドをする
 
 ##### 事前準備
 
@@ -98,7 +98,7 @@ _build/ubuntu-20.04_x86_64/release/messaging_recvonly_sample/
 └── messaging_recvonly_sample
 ```
 
-#### Ubuntu 22.04 x86_64 向けのビルドをする
+#### Ubuntu 22.04 x86_64 Desktop 向けのビルドをする
 
 ##### 事前準備
 
@@ -121,7 +121,7 @@ _build/ubuntu-22.04_x86_64/release/messaging_recvonly_sample/
 └── messaging_recvonly_sample
 ```
 
-#### Ubuntu 24.04 x86_64 向けのビルドをする
+#### Ubuntu 24.04 x86_64 Desktop 向けのビルドをする
 
 ##### 事前準備
 

--- a/examples/sdl_sample/README.md
+++ b/examples/sdl_sample/README.md
@@ -76,7 +76,7 @@ _build/macos_arm64/release/sdl_sample
 └── sdl_sample
 ```
 
-#### Ubuntu 20.04 x86_64 向けのビルドをする
+#### Ubuntu 20.04 x86_64 Desktop 向けのビルドをする
 
 ##### 事前準備
 
@@ -99,7 +99,7 @@ _build/ubuntu-20.04_x86_64/release/sdl_sample/
 └── sdl_sample
 ```
 
-#### Ubuntu 22.04 x86_64 向けのビルドをする
+#### Ubuntu 22.04 x86_64 Desktop 向けのビルドをする
 
 ##### 事前準備
 
@@ -122,7 +122,7 @@ _build/ubuntu-22.04_x86_64/release/sdl_sample/
 └── sdl_sample
 ```
 
-#### Ubuntu 24.04 x86_64 向けのビルドをする
+#### Ubuntu 24.04 x86_64 Desktop 向けのビルドをする
 
 ##### 事前準備
 

--- a/examples/sumomo/README.md
+++ b/examples/sumomo/README.md
@@ -76,7 +76,7 @@ _build/macos_arm64/release/sumomo
 └── sumomo
 ```
 
-#### Ubuntu 20.04 x86_64 向けのビルドをする
+#### Ubuntu 20.04 x86_64 Desktop 向けのビルドをする
 
 ##### 事前準備
 
@@ -99,7 +99,7 @@ _build/ubuntu-20.04_x86_64/release/sumomo/
 └── sumomo
 ```
 
-#### Ubuntu 22.04 x86_64 向けのビルドをする
+#### Ubuntu 22.04 x86_64 Desktop 向けのビルドをする
 
 ##### 事前準備
 
@@ -122,7 +122,7 @@ _build/ubuntu-22.04_x86_64/release/sumomo/
 └── sumomo
 ```
 
-#### Ubuntu 24.04 x86_64 向けのビルドをする
+#### Ubuntu 24.04 x86_64 Desktop 向けのビルドをする
 
 ##### 事前準備
 


### PR DESCRIPTION
Ubuntu のバージョンについて、デスクトップであることを明記しました。
VPL ドキュメントにも記載がありますが、そちらは VPL のドキュメントの修正と同時に行います。

----

This pull request includes updates to the `README.md` files for various examples to clarify the build instructions for different Ubuntu versions. The changes specify that the build instructions are for the "Desktop" versions of Ubuntu.

Updates to build instructions:

* [`examples/messaging_recvonly_sample/README.md`](diffhunk://#diff-2c9cd21bb3d0448f7db36430f0af831168fa31fc4808bf80bbf07cd4bbc3198eL78-R78): Updated build instructions for Ubuntu 20.04, 22.04, and 24.04 to specify "Desktop" versions. [[1]](diffhunk://#diff-2c9cd21bb3d0448f7db36430f0af831168fa31fc4808bf80bbf07cd4bbc3198eL78-R78) [[2]](diffhunk://#diff-2c9cd21bb3d0448f7db36430f0af831168fa31fc4808bf80bbf07cd4bbc3198eL101-R101) [[3]](diffhunk://#diff-2c9cd21bb3d0448f7db36430f0af831168fa31fc4808bf80bbf07cd4bbc3198eL124-R124)
* [`examples/sdl_sample/README.md`](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L79-R79): Updated build instructions for Ubuntu 20.04, 22.04, and 24.04 to specify "Desktop" versions. [[1]](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L79-R79) [[2]](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L102-R102) [[3]](diffhunk://#diff-9b3c5a5912c8b496cdfa8674dfa807b4c2fad0daa88d558e11d5645a10f10a44L125-R125)
* [`examples/sumomo/README.md`](diffhunk://#diff-69266961f03c6c5468fe9c75cc51875aecb5d0043558e250b2142ba3f11c0f8fL79-R79): Updated build instructions for Ubuntu 20.04, 22.04, and 24.04 to specify "Desktop" versions. [[1]](diffhunk://#diff-69266961f03c6c5468fe9c75cc51875aecb5d0043558e250b2142ba3f11c0f8fL79-R79) [[2]](diffhunk://#diff-69266961f03c6c5468fe9c75cc51875aecb5d0043558e250b2142ba3f11c0f8fL102-R102) [[3]](diffhunk://#diff-69266961f03c6c5468fe9c75cc51875aecb5d0043558e250b2142ba3f11c0f8fL125-R125)