### PR TITLE
GitHub Actions の Windows でのビルドが失敗する問題を修正

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,6 +256,7 @@ jobs:
       - name: Install deps for ${{ matrix.platform.name }}
         if: matrix.platform.os == 'ubuntu' && matrix.platform.arch == 'armv8'
         run: |
+          sudo apt-get update
           sudo apt-get -y install multistrap binutils-aarch64-linux-gnu libgl-dev
           # multistrap に insecure なリポジトリからの取得を許可する設定を入れる
           sudo sed -e 's/Apt::Get::AllowUnauthenticated=true/Apt::Get::AllowUnauthenticated=true";\n$config_str .= " -o Acquire::AllowInsecureRepositories=true/' -i /usr/sbin/multistrap

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,13 @@
   - NvCodecVideoEncoder の `ImplementationName` は `NvCodec` になっているので、合わせる
   - @torikizi
 
+### misc
+
+- [FIX] GitHub Actions の Windows でのビルドが失敗する問題を修正
+  - Github Actions のランナーアップデートによって MSVC のバージョンが変わり、ビルドが失敗する問題が発生していた
+  - Boost.Process の v1 を利用するように修正
+  - @torikizi
+
 ## 2025.1.0
 
 **リリース日**: 2025-01-27

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@
 - [FIX] GitHub Actions の Windows でのビルドが失敗する問題を修正
   - Github Actions のランナーアップデートによって MSVC のバージョンが変わり、ビルドが失敗する問題が発生していた
   - Boost.Process の v1 を利用するように修正
+  - Boost.Process の v1 を利用することでなくなった `chrono` をインクルードするように修正
   - @torikizi
 
 ## 2025.1.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,8 +65,10 @@
 
 - [FIX] GitHub Actions の Windows でのビルドが失敗する問題を修正
   - Microsoft Visual C++ のバージョン `14.42.34438` 以降で、ビルドが失敗する問題が発生していた
-  - Boost.Process の v2 を利用するように修正
   - `chrono` をインクルードするように修正
+  - @torikizi
+- [FIX] test/e2e.cpp の不要なインクルードを削除
+  - `Boost.Process` のインクルードが不要だったので削除
   - @torikizi
 
 ## 2025.1.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -61,9 +61,9 @@
 ### misc
 
 - [FIX] GitHub Actions の Windows でのビルドが失敗する問題を修正
-  - Github Actions のランナーアップデートによって MSVC のバージョンが変わり、ビルドが失敗する問題が発生していた
-  - Boost.Process の v1 を利用するように修正
-  - Boost.Process の v1 を利用することでなくなった `chrono` をインクルードするように修正
+  - Microsoft Visual C++ のバージョン `14.42.34438` 以降で、ビルドが失敗する問題が発生していた
+  - Boost.Process の v2 を利用するように修正
+  - `chrono` をインクルードするように修正
   - @torikizi
 
 ## 2025.1.0

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -57,6 +57,9 @@
 - [FIX] `NvCodecVideoDecoder` の `ImplementationName` を `NvCodec` に修正する
   - NvCodecVideoEncoder の `ImplementationName` は `NvCodec` になっているので、合わせる
   - @torikizi
+- [FIX] Ubuntu-24.04_armv8 でビルドが失敗する問題を修正
+  - `apt-get install` で `binutils-aarch64-linux-gnu` のパッケージが 404 エラーになったため build.yml に `apt-get update` を追加
+  - @torikizi
 
 ### misc
 

--- a/test/e2e.cpp
+++ b/test/e2e.cpp
@@ -14,9 +14,6 @@
 // Catch2
 #include <catch2/catch_test_macros.hpp>
 
-// Boost.Process
-#include <boost/process/v2/environment.hpp>
-
 // Sora
 #include <sora/audio_device_module.h>
 #include <sora/camera_device_capturer.h>

--- a/test/e2e.cpp
+++ b/test/e2e.cpp
@@ -15,7 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 // Boost.Process
-#include <boost/process/env.hpp>
+#include <boost/process/v1/env.hpp>
 
 // Sora
 #include <sora/audio_device_module.h>

--- a/test/e2e.cpp
+++ b/test/e2e.cpp
@@ -15,7 +15,7 @@
 #include <catch2/catch_test_macros.hpp>
 
 // Boost.Process
-#include <boost/process/v1/env.hpp>
+#include <boost/process/v2/environment.hpp>
 
 // Sora
 #include <sora/audio_device_module.h>

--- a/test/fake_video_capturer.cpp
+++ b/test/fake_video_capturer.cpp
@@ -1,5 +1,6 @@
 #include "fake_video_capturer.h"
 
+#include <chrono>
 #include <memory>
 #include <thread>
 


### PR DESCRIPTION
Github Actions のランナーアップデートに追従し、Windows のビルドエラーを修正する

---

This pull request includes several important changes to address build issues and update dependencies. The changes ensure compatibility with the latest GitHub Actions runner and fix the build process on Windows.

Updates and fixes:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R61-R68): Added a section under "misc" to document the fix for the build failure issue on Windows due to the MSVC version change. Updated to use Boost.Process v1 and included the `chrono` header.

Dependency updates:

* [`test/e2e.cpp`](diffhunk://#diff-3f067c34ecd01532d6d3b4e9c45f8c4d1abcb9b700c16e093f8699261c97ab2aL18-R18): Updated the include directive to use `boost/process/v1/env.hpp` instead of `boost/process/env.hpp`.
* [`test/fake_video_capturer.cpp`](diffhunk://#diff-3a683fab2587505ba6deafb023ce642f6f5d1d84141eb601459b4617509b46dbR3): Included the `chrono` header to ensure compatibility with Boost.Process v1.