### PR TITLE
Ubuntu-24.04_armv8 でも apt update をする

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -256,6 +256,7 @@ jobs:
       - name: Install deps for ${{ matrix.platform.name }}
         if: matrix.platform.os == 'ubuntu' && matrix.platform.arch == 'armv8'
         run: |
+          sudo apt-get update
           sudo apt-get -y install multistrap binutils-aarch64-linux-gnu libgl-dev
           # multistrap に insecure なリポジトリからの取得を許可する設定を入れる
           sudo sed -e 's/Apt::Get::AllowUnauthenticated=true/Apt::Get::AllowUnauthenticated=true";\n$config_str .= " -o Acquire::AllowInsecureRepositories=true/' -i /usr/sbin/multistrap


### PR DESCRIPTION
- `apt-get install` で `binutils-aarch64-linux-gnu` のパッケージが 404 エラーになったため build.yml に `apt-get update` を追加

---

This pull request includes a small change to the `.github/workflows/build.yml` file. The change ensures that the package list is updated before installing dependencies on the `ubuntu` platform with `armv8` architecture.

* [`.github/workflows/build.yml`](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721R259): Added `sudo apt-get update` command to update the package list before installing dependencies.