### PR TITLE
chrono をインクルードするようにする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,13 @@
   - NvCodecVideoEncoder の `ImplementationName` は `NvCodec` になっているので、合わせる
   - @torikizi
 
+### misc
+
+- [FIX] GitHub Actions の Windows でのビルドが失敗する問題を修正
+  - Microsoft Visual C++ のバージョン `14.42.34438` 以降では `<chrono>` ヘッダの明示的なインクルードが必要となったため、ビルドエラーが発生していた
+  - `<chrono>` をインクルードするように修正
+  - @torikizi
+
 ## 2025.1.0
 
 **リリース日**: 2025-01-27

--- a/test/fake_video_capturer.cpp
+++ b/test/fake_video_capturer.cpp
@@ -1,5 +1,6 @@
 #include "fake_video_capturer.h"
 
+#include <chrono>
 #include <memory>
 #include <thread>
 


### PR DESCRIPTION
fake_video_capturer.cpp に chrono をインクルードするように修正

---

This pull request addresses a build failure issue on Windows for GitHub Actions by including the `<chrono>` header explicitly. Below are the key changes:

Build Fix:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R61-R67): Added a new entry under the "misc" section detailing the fix for the Windows build failure caused by the need for an explicit `<chrono>` header include due to updates in Microsoft Visual C++.
* [`test/fake_video_capturer.cpp`](diffhunk://#diff-3a683fab2587505ba6deafb023ce642f6f5d1d84141eb601459b4617509b46dbR3): Included the `<chrono>` header to resolve build errors on Windows.