### PR TITLE
Boost.Process の include は未使用だったので削除する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,11 @@
   - NvCodecVideoEncoder の `ImplementationName` は `NvCodec` になっているので、合わせる
   - @torikizi
 
+### misc
+
+- [FIX] test/e2e.cpp の利用していない include を削除する
+  - @torikizi
+
 ## 2025.1.0
 
 **リリース日**: 2025-01-27

--- a/test/e2e.cpp
+++ b/test/e2e.cpp
@@ -14,9 +14,6 @@
 // Catch2
 #include <catch2/catch_test_macros.hpp>
 
-// Boost.Process
-#include <boost/process/env.hpp>
-
 // Sora
 #include <sora/audio_device_module.h>
 #include <sora/camera_device_capturer.h>


### PR DESCRIPTION
test/e2e.cpp の利用していない include を削除する

---

This pull request includes a minor update to the `CHANGES.md` file and the removal of an unused include directive in the `test/e2e.cpp` file.

Documentation update:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R61-R65): Added a new section under "misc" to document the removal of unused include directives in `test/e2e.cpp`.

Code cleanup:

* [`test/e2e.cpp`](diffhunk://#diff-3f067c34ecd01532d6d3b4e9c45f8c4d1abcb9b700c16e093f8699261c97ab2aL17-L19): Removed unused `#include <boost/process/env.hpp>` directive to clean up the code.