### PR TITLE
layer_frames が空の場合のチェックを追加

### DIFF
--- a/src/hwenc_amf/amf_video_encoder.cpp
+++ b/src/hwenc_amf/amf_video_encoder.cpp
@@ -475,6 +475,8 @@ AMF_RESULT AMFVideoEncoderImpl::ProcessBuffer(amf::AMFBufferPtr buffer,
         encoded_image_._frameType == webrtc::VideoFrameType::kVideoFrameKey;
     std::vector<webrtc::ScalableVideoController::LayerFrameConfig>
         layer_frames = svc_controller_->NextFrameConfig(is_key);
+    // AV1 の SVC では、まれにエンコード対象のレイヤーフレームが存在しない場合がある。
+    // 次のフレームを待つことで正常に継続可能なケースであるため、エラーではなく正常終了の AMF_OK を返してスキップする。
     if (layer_frames.empty()) {
       return AMF_OK;
     }

--- a/src/hwenc_amf/amf_video_encoder.cpp
+++ b/src/hwenc_amf/amf_video_encoder.cpp
@@ -475,6 +475,9 @@ AMF_RESULT AMFVideoEncoderImpl::ProcessBuffer(amf::AMFBufferPtr buffer,
         encoded_image_._frameType == webrtc::VideoFrameType::kVideoFrameKey;
     std::vector<webrtc::ScalableVideoController::LayerFrameConfig>
         layer_frames = svc_controller_->NextFrameConfig(is_key);
+    if (layer_frames.empty()) {
+      return AMF_OK;
+    }
     codec_specific.end_of_picture = true;
     codec_specific.scalability_mode = scalability_mode_;
     codec_specific.generic_frame_info =


### PR DESCRIPTION
layer_frames が空になる場合、AMF_OK を返すように変更しました

----

This pull request includes a change to the `AMFVideoEncoderImpl::ProcessBuffer` method in the `amf_video_encoder.cpp` file. The change adds a check to return `AMF_OK` if the `layer_frames` vector is empty.

Codebase improvement:

* [`src/hwenc_amf/amf_video_encoder.cpp`](diffhunk://#diff-7b2e0fc257a46b38ad20889f4194743420c7fa229f3d49b700044f15e985ed2aR478-R480): Added a condition to return `AMF_OK` if `layer_frames` is empty in the `AMFVideoEncoderImpl::ProcessBuffer` method.