### PR TITLE
c_cpp_properties.json から ubuntu-20.04_armv8_jetson の設定を削除

### DIFF
--- a/.vscode/c_cpp_properties.json
+++ b/.vscode/c_cpp_properties.json
@@ -1,39 +1,6 @@
 {
     "configurations": [
         {
-            "name": "ubuntu-20.04_armv8_jetson Release",
-            "includePath": [
-                "${workspaceFolder}/_install/ubuntu-20.04_armv8_jetson/release/boost/include",
-                "${workspaceFolder}/_install/ubuntu-20.04_armv8_jetson/release/webrtc/include",
-                "${workspaceFolder}/_install/ubuntu-20.04_armv8_jetson/release/webrtc/include/third_party/abseil-cpp",
-                "${workspaceFolder}/_install/ubuntu-20.04_armv8_jetson/release/webrtc/include/third_party/boringssl/src/include",
-                "${workspaceFolder}/_install/ubuntu-20.04_armv8_jetson/release/webrtc/include/third_party/libyuv/include",
-                "${workspaceFolder}/_install/ubuntu-20.04_armv8_jetson/release/webrtc/include/third_party/zlib",
-                "${workspaceFolder}/_install/ubuntu-20.04_armv8_jetson/release/llvm/libcxx/include",
-                "${workspaceFolder}/_install/ubuntu-20.04_armv8_jetson/release/sora",
-                "${workspaceFolder}/_install/ubuntu-20.04_armv8_jetson/release/rootfs/usr/src/jetson_multimedia_api/include",
-                "${workspaceFolder}/_install/ubuntu-20.04_armv8_jetson/release/rootfs/usr/src/jetson_multimedia_api/include/libjpeg-8b",
-                "${workspaceFolder}/_install/ubuntu-20.04_armv8_jetson/release/blend2d/include",
-                "${workspaceFolder}/_build/ubuntu-20.04_armv8_jetson/release/sora",
-                "${workspaceFolder}/include"
-            ],
-            "defines": [
-                "WEBRTC_POSIX",
-                "_LIBCPP_ABI_UNSTABLE",
-                "_LIBCPP_DISABLE_AVAILABILITY",
-                "OPENSSL_IS_BORINGSSL",
-                "USE_JETSON_ENCODER",
-                "SORA_CPP_SDK_JETSON",
-                "HELLO_JETSON",
-                "RTC_ENABLE_H265"
-            ],
-            "compilerPath": "${workspaceFolder}/_install/ubuntu-20.04_armv8_jetson/release/llvm/clang/bin/clang++",
-            "compilerArgs": ["-nostdinc++"],
-            "cStandard": "gnu17",
-            "cppStandard": "gnu++17",
-            "intelliSenseMode": "linux-clang-x64"
-        },
-        {
             "name": "ubuntu-22.04_x86_64 Release",
             "includePath": [
                 "${workspaceFolder}/_install/ubuntu-22.04_x86_64/release/boost/include",


### PR DESCRIPTION
This pull request includes a change to the `.vscode/c_cpp_properties.json` file, specifically removing the configuration for the "ubuntu-20.04_armv8_jetson Release" environment.

Configuration removal:

* [`.vscode/c_cpp_properties.json`](diffhunk://#diff-8f4e8cf66ff6479868eeeb084ef19fbb8bea6102cf86f8adec2180dcf38dc47dL3-L35): Removed the "ubuntu-20.04_armv8_jetson Release" configuration, including its `includePath`, `defines`, `compilerPath`, `compilerArgs`, `cStandard`, `cppStandard`, and `intelliSenseMode` settings.