### PR TITLE
NVIDIA Video Codec SDK を 12.1 にアップデート

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,6 +11,13 @@
 
 ## develop
 
+- [UPDATE] `third_party/NvCodec` を 12.1 にアップデート
+  - README のライセンスバージョンを更新
+  - NOTICE の `cuviddec.h / nvEncodeAPI.h / nvcuvid.h` を更新
+  - `nvcodec_video_encoder.cpp` でコメントアウトしていた箇所を削除
+    - すでに利用していないことと `NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ` が削除されたため
+  - @torikizi
+
 ### misc
 
 - [UPDATE] `third_party` の運用方針を見直し

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -12,9 +12,12 @@
 ## develop
 
 - [UPDATE] `third_party/NvCodec` を 12.1 にアップデート
-  - README のライセンスバージョンを更新
-  - README にライセンスのリンクを追加
-  - NOTICE の `cuviddec.h / nvEncodeAPI.h / nvcuvid.h` を更新
+  - README の更新
+    - ライセンスバージョンを更新
+    - ライセンスのリンクを追加
+  - NOTICE の更新
+    - `cuviddec.h / nvEncodeAPI.h / nvcuvid.h` を更新
+    - `NvDecoder / NvEncoder` のライセンスを更新
   - `nvcodec_video_encoder.cpp` でコメントアウトしていた箇所を削除
     - すでに利用していないことと `NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ` が削除されたため
   - @torikizi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -18,8 +18,9 @@
   - NOTICE の更新
     - `cuviddec.h / nvEncodeAPI.h / nvcuvid.h` を更新
     - `NvDecoder / NvEncoder` のライセンスを更新
-  - `nvcodec_video_encoder.cpp` でコメントアウトしていた箇所を削除
-    - すでに利用していないことと `NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ` が削除されたため
+  - `nvcodec_video_encoder.cpp` の未使用コードを削除
+    - NvCodec からの `NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ` 削除に伴い、コメントアウトされていたコードを削除
+    - 未使用かつコメントアウトされていた `NV_ENC_H264_PROFILE_BASELINE_GUID` のコードも削除
   - @torikizi
 
 ### misc

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
 
 - [UPDATE] `third_party/NvCodec` を 12.1 にアップデート
   - README のライセンスバージョンを更新
+  - README にライセンスのリンクを追加
   - NOTICE の `cuviddec.h / nvEncodeAPI.h / nvcuvid.h` を更新
   - `nvcodec_video_encoder.cpp` でコメントアウトしていた箇所を削除
     - すでに利用していないことと `NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ` が削除されたため

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -99,222 +99,31 @@ OTHER DEALINGS IN THE SOFTWARE.
 
 ## NvDecoder / NvEncoder
 
-https://developer.nvidia.com/nvidia-video-codec-sdk-license-agreement
-
 ```
-NVIDIA VIDEO CODEC SDK LICENSE AGREEMENT (“Agreement”)
+This copyright notice applies to this header file only:
 
-BY DOWNLOADING, INSTALLING OR USING THE SOFTWARE AND OTHER AVAILABLE MATERIALS,
-YOU (“LICENSEE”) AGREE TO BE BOUND BY THE FOLLOWING TERMS AND CONDITIONS OF
-THIS AGREEMENT.  If Licensee does not agree to the terms and condition of this
-Agreement, THEN do not downLOAD, INSTALL OR USE the SOFTWARE AND MATERIALS.
+Copyright (c) 2010-2023 NVIDIA Corporation
 
-The materials available for download to Licensees may include software in both
-sample source code ("Source Code") and object code ("Object Code") versions
-(collectively, the “Software”), documentation and other materials
-(collectively, these code and materials referred to herein as "Licensed
-Materials").  Except as expressly indicated herein, all terms and conditions of
-this Agreement apply to all of the Licensed Materials.
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the software, and to permit persons to whom the
+software is furnished to do so, subject to the following
+conditions:
 
-Except as expressly set forth herein, NVIDIA owns all of the Licensed Materials
-and makes them available to Licensee only under the terms and conditions set
-forth in this Agreement.
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
 
-License:  Subject to Licensee’s compliance with the terms of this Agreement,
-NVIDIA grants to Licensee a nonexclusive, non-transferable, worldwide,
-royalty-free, fully paid-up license and right to install, use, reproduce,
-display, perform, modify the Source Code of the Software, and to prepare and
-have prepared derivative works thereof, and distribute the Software and
-derivative works thereof (in object code only) as integrated in Licensee
-software products solely for use with supported NVIDIA GPU hardware products as
-specified in the accompanying release notes.  The following terms apply to the
-Licensed Material:
-
-Derivative Works:  Subject to the License Grant Back below, Licensee shall own
-any Derivative Works it creates directly to the Source Code that integrates
-with Licensee’s software product ("Modification(s)") subject to NVIDIA’s
-ownership of the underlying Source Code and all intellectual property rights
-therein.
-
-Distribution: Licensee may distribute the Software (in object code form)
-integrated with Licensee software products only to Licensee’s authorized
-distributors, resellers, and others in Licensee’s distribution chain for
-Licensee product and end users and grant to such third party a sublicense to
-use the Software under a written, legally enforceable agreement that has the
-effect of protecting the Software and the rights of NVIDIA under terms no less
-restrictive than this Agreement.
-
-Limitations: Unless otherwise authorized in the Agreement, Licensee shall not
-otherwise assign, sublicense, lease, or in any other way transfer or disclose
-Software to any third party. Licensee agrees not to disassemble, decompile or
-reverse engineer the Object Code or use or modify any of the Licensed Materials
-to enable screen scraping, data scraping, or any other activity with the
-purpose of capturing copyright protected content in violation of a third party
-party’s intellectual property or other proprietary rights.  Licensee shall
-indemnify NVIDIA for any and all claims, liabilities, damages, expenses and
-costs arising from Licensee’s breach of the foregoing limitations.
-
-License Grant Back:Licensee hereby grants to NVIDIA and its affiliates a
-worldwide, non-exclusive, irrevocable, perpetual, sublicenseable (through
-multiple tiers of sublicensees), royalty-free and fully paid-up right and
-license to the Modification(s) created by or on behalf of Licensee so that
-NVIDIA may copy, modify, create derivatives works thereof, to use, have used,
-import, make, have made, sell, offer to sell, sublicense (through multiple
-tiers of sublicensees), distribute (through multiple tiers of distributors)
-such derivative work(s) on a stand-alone basis or as incorporated into the
-Licensed Materials or other related technologies.  For the sake of clarity,
-NVIDIA is not prohibited or otherwise restricted from independently developing
-new features or functionality with respect to the Licensed Materials
-
-No Other License:No rights or licenses with respect to any proprietary
-information or patent, copyright, trade secret or other intellectual property
-right owned or controlled by NVIDIA are granted by NVIDIA to Licensee under
-this Agreement, expressly or by implication, except as expressly provided in
-this Agreement.
-
-Confidentiality: If applicable, any exchange of Confidential Information (as
-defined in the NDA) shall be made pursuant to the terms and conditions of a
-separately signed Non-Disclosure Agreement (“NDA”) by and between NVIDIA and
-You. For the sake of clarity, You agree that (a) the Software (in source code
-form); and (b) Your use of the Software is considered Confidential Information
-of NVIDIA.
-
-If You wish to have a third party consultant or subcontractor ("Contractor")
-perform work on Your behalf which involves access to or use of Software, You
-shall obtain a written confidentiality agreement from the Contractor which
-contains terms and obligations with respect to access to or use of Software no
-less restrictive than those set forth in this Agreement and excluding any
-distribution or sublicense rights, and use for any other purpose than permitted
-in this Agreement. Otherwise, You shall not disclose the terms or existence of
-this Agreement or use NVIDIA's name in any publications, advertisements, or
-other announcements without NVIDIA's prior written consent.  Unless otherwise
-provided in this Agreement, You do not have any rights to use any NVIDIA
-trademarks or logos.
-
-Intellectual Property Ownership: Except as expressly licensed to Licensee under
-this Agreement, NVIDIA reserves all right, title and interest, including but
-not limited to all intellectual property rights, in and to the Licensed
-Materials and any derivative work(s) made thereto. The algorithms, structure,
-organization and Source Code are the valuable trade secrets and confidential
-information of NVIDIA.
-
-Licensee acknowledges and agrees that it is Licensee’s sole responsibility to
-obtain any, additional, third party licenses required to make, have made, use,
-have used, sell, import, and offer for sale Licensee products that include or
-incorporate any third party technology such as operating systems, audio and/or
-video encoders and decoders or any technology from, including but not limited
-to, Microsoft, Thomson, Fraunhofer IIS, Sisvel S.p.A., MPEG-LA, and Coding
-Technologies (“Third Party Technology”).  Licensee acknowledges and agrees that
-NVIDIA has not granted to Licensee under this Agreement any necessary patent
-rights with respect to the Third Party Technology.  As such, Licensee’s use of
-the Third Party Technology may be subject to further restrictions and terms and
-conditions.  Licensee acknowledges and agrees that Licensee is solely and
-exclusively responsible for obtaining any and all authorizations and licenses
-required for the use, distribution and/or incorporation of the Third Party
-Technology.
-
-Licensee shall, at its own expense fully indemnify, hold harmless, defend
-and/or settle any claim, suit or proceeding that is asserted by a third party
-against NVIDIA and its officers, employees or agents, to the extent such claim,
-suit or proceeding arising from or related to Licensee’s failure to fully
-satisfy and/or comply with the third party licensing obligations related to the
-Third Party Technology (a “Claim”).  In the event of a Claim, Licensee agrees
-to: (a) pay all damages or settlement amounts, which shall not be finalized
-without the prior written consent of NVIDIA, (including other reasonable costs
-incurred by NVIDIA, including reasonable attorneys fees, in connection with
-enforcing this paragraph); (b) reimburse NVIDIA for any licensing fees and/or
-penalties incurred by NVIDIA in connection with a Claim; and (c) immediately
-procure/satisfy the third party licensing obligations before using the Software
-pursuant to this Agreement.
-
-Term of Agreement:  This Agreement shall become effective from the date of the
-initial download and shall remain in effect for one year thereafter, unless
-terminated as provided below.  Unless either party notifies the other party of
-its intent to terminate this Agreement at least thirty (30) days prior to the
-end of the Initial Term or the applicable renewal period, this Agreement will
-be automatically renewed for one (1) year renewal periods thereafter, unless
-terminated in accordance with the “Termination” provision of this Agreement.
-
-NVIDIA may terminate this Agreement (and with it, all of Licensee’s right to
-the Licensed Materials) if (i) Licensee fails to comply with any of the terms
-and conditions of this Agreement and if the breach is not cured within thirty
-(30) days after notice thereof. Upon expiration or termination of this
-Agreement pursuant to this paragraph, Licensee shall immediately cease using
-the Licensed Materials and return or destroy or copies thereof in its
-possession.
-
-Defensive Suspension:If Licensee commences or participates in any legal
-proceeding against NVIDIA, then NVIDIA may, in its sole discretion, suspend or
-terminate all license grants and any other rights provided under this
-Agreement.
-
-No Support:  NVIDIA has no obligation to support or to continue providing or
-updating any of the Licensed Materials.
-
-No Warranty:  THE LICENSED MATERIALS PROVIDED BY NVIDIA TO LICENSEE HEREUNDER
-ARE PROVIDED "AS IS."  NVIDIA DISCLAIMS ALL WARRANTIES, EXPRESS, IMPLIED OR
-STATUTORY, INCLUDING, WITHOUT LIMITATION, THE IMPLIED WARRANTIES OF TITLE,
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-
-Limitation of Liability: NVIDIA SHALL NOT BE LIABLE TO LICENSEE, LICENSEE’S
-CUSTOMERS, OR ANY OTHER PERSON OR ENTITY CLAIMING THROUGH OR UNDER LICENSEE FOR
-ANY LOSS OF PROFITS, INCOME, SAVINGS, OR ANY OTHER CONSEQUENTIAL, INCIDENTAL,
-SPECIAL, PUNITIVE, DIRECT OR INDIRECT DAMAGES (WHETHER IN AN ACTION IN
-CONTRACT, TORT OR BASED ON A WARRANTY), EVEN IF NVIDIA HAS BEEN ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGES.  THESE LIMITATIONS SHALL APPLY NOTWITHSTANDING ANY
-FAILURE OF THE ESSENTIAL PURPOSE OF ANY LIMITED REMEDY.  IN NO EVENT SHALL
-NVIDIA’S AGGREGATE LIABILITY TO LICENSEE OR ANY OTHER PERSON OR ENTITY CLAIMING
-THROUGH OR UNDER LICENSEE EXCEED THE AMOUNT OF MONEY ACTUALLY PAID BY LICENSEE
-TO NVIDIA FOR THE LICENSED MATERIALS.
-
-Applicable Law and Jurisdiction: This Agreement shall be deemed to have been
-made in, and shall be construed pursuant to, the laws of the State of Delaware.
-The state and/or federal courts residing in Santa Clara County, California
-shall have exclusive jurisdiction over any dispute or claim arising out of this
-Agreement. The United Nations Convention on Contracts for the International
-Sale of Goods is specifically disclaimed.
-
-Feedback:Licensee may, but is not obligated to, provide to NVIDIA any
-suggestions, comments and feedback regarding the Licensed Materials that are
-delivered by NVIDIA to Licensee under this Agreement (collectively, “Licensee
-Feedback”).  NVIDIA may use and include any Licensee Feedback that Licensee
-voluntarily provides to improve the Licensed Materials or other related NVIDIA
-technologies.  Accordingly, if Licensee provides Licensee Feedback, Licensee
-grants NVIDIA and its licensees a perpetual, irrevocable, worldwide,
-royalty-free, fully paid-up license grant to freely use, have used, sell,
-modify, reproduce, transmit, license, sublicense (through multiple tiers of
-sublicensees), distribute (through multiple tiers of distributors), and
-otherwise commercialize the Licensee Feedback in the Licensed Materials or
-other related technologies.
-
-RESTRICTED RIGHTS NOTICE: Licensed Materials has been developed entirely at
-private expense and is commercial computer software provided with RESTRICTED
-RIGHTS. Use, duplication or disclosure by the U.S. Government or a U.S.
-Government subcontractor is subject to the restrictions set forth in the
-license agreement under which Licensed Materials was obtained pursuant to DFARS
-227.7202-3(a) or as set forth in subparagraphs (c)(1) and (2) of the Commercial
-Computer Software - Restricted Rights clause at FAR 52.227-19, as applicable.
-Contractor/manufacturer is NVIDIA, 2701 San Tomas Expressway, Santa Clara, CA
-95050.
-
-Miscellaneous: If any provision of this Agreement is inconsistent with, or
-cannot be fully enforced under, the law, such provision will be construed as
-limited to the extent necessary to be consistent with and fully enforceable
-under the law. This Agreement is the final, complete and exclusive agreement
-between the parties relating to the subject matter hereof, and supersedes all
-prior or contemporaneous understandings and agreements relating to such subject
-matter, whether oral or written. This Agreement is solely between NVIDIA and
-Licensee.  There are no third party beneficiaries, express or implied, to this
-Agreement. This Agreement may only be modified in writing signed by an
-authorized officer of NVIDIA.  Licensee agrees that it will not ship, transfer
-or export the Licensed Materials into any country, or use the Licensed
-Materials in any manner, prohibited by the United States Bureau of Industry and
-Security or any export laws, restrictions or regulations. This Agreement, and
-Licensee’s rights and obligations herein, may not be assigned, subcontracted,
-delegated, or otherwise transferred by Licensee without NVIDIA’s prior written
-consent, and any attempted assignment, subcontract, delegation, or transfer in
-violation of the foregoing will be null and void.   The terms of this Agreement
-shall be binding upon assignees.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
 ```
 
 ## L4T Multimedia API

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -73,7 +73,7 @@ DEALINGS IN THE SOFTWARE.
 ```
 This copyright notice applies to this header file only:
 
-Copyright (c) 2010-2019 NVIDIA Corporation
+Copyright (c) 2010-2023 NVIDIA Corporation
 
 Permission is hereby granted, free of charge, to any person
 obtaining a copy of this software and associated documentation

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ limitations under the License.
 
 ## NVDIA Video Codec SDK
 
-<https://docs.nvidia.com/video-technologies/video-codec-sdk/12.0/index.html>
+<https://docs.nvidia.com/video-technologies/video-codec-sdk/12.1/index.html>
 
 ```test
 “This software contains source code provided by NVIDIA Corporation.”

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ limitations under the License.
 "OpenH264 Video Codec provided by Cisco Systems, Inc."
 ```
 
-## NVDIA Video Codec SDK
+## NVIDIA Video Codec SDK
 
 <https://docs.nvidia.com/video-technologies/video-codec-sdk/12.1/index.html>
 

--- a/README.md
+++ b/README.md
@@ -151,6 +151,6 @@ limitations under the License.
 
 <https://docs.nvidia.com/video-technologies/video-codec-sdk/12.1/license/index.html>
 
-```test
+```text
 “This software contains source code provided by NVIDIA Corporation.”
 ```

--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ limitations under the License.
 
 <https://docs.nvidia.com/video-technologies/video-codec-sdk/12.1/index.html>
 
+
+<https://docs.nvidia.com/video-technologies/video-codec-sdk/12.1/license/index.html>
+
 ```test
 “This software contains source code provided by NVIDIA Corporation.”
 ```

--- a/src/hwenc_nvcodec/nvcodec_video_encoder.cpp
+++ b/src/hwenc_nvcodec/nvcodec_video_encoder.cpp
@@ -615,7 +615,6 @@ std::unique_ptr<NvEncoder> NvCodecVideoEncoderImpl::CreateEncoder(
     initialize_params.maxEncodeWidth = width;
     initialize_params.maxEncodeHeight = height;
 
-    //encode_config.profileGUID = NV_ENC_H264_PROFILE_BASELINE_GUID;
     encode_config.rcParams.averageBitRate = target_bitrate_bps;
     encode_config.rcParams.maxBitRate = max_bitrate_bps;
 

--- a/src/hwenc_nvcodec/nvcodec_video_encoder.cpp
+++ b/src/hwenc_nvcodec/nvcodec_video_encoder.cpp
@@ -616,7 +616,6 @@ std::unique_ptr<NvEncoder> NvCodecVideoEncoderImpl::CreateEncoder(
     initialize_params.maxEncodeHeight = height;
 
     //encode_config.profileGUID = NV_ENC_H264_PROFILE_BASELINE_GUID;
-    //encode_config.rcParams.rateControlMode = NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ;
     encode_config.rcParams.averageBitRate = target_bitrate_bps;
     encode_config.rcParams.maxBitRate = max_bitrate_bps;
 

--- a/third_party/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp
+++ b/third_party/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp
@@ -25,6 +25,8 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
+ #include "sora/fix_cuda_noinline_macro_error.h"
+
 #include <iostream>
 #include <algorithm>
 #include <chrono>

--- a/third_party/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp
+++ b/third_party/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp
@@ -1,15 +1,29 @@
 /*
-* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
-*
-* Please refer to the NVIDIA end user license agreement (EULA) associated
-* with this source code for terms and conditions that govern your use of
-* this software. Any use, reproduction, disclosure, or distribution of
-* this software and related documentation outside the terms of the EULA
-* is strictly prohibited.
-*
-*/
-
-#include "sora/fix_cuda_noinline_macro_error.h"
+ * This copyright notice applies to this header file only:
+ *
+ * Copyright (c) 2010-2023 NVIDIA Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the software, and to permit persons to whom the
+ * software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 #include <iostream>
 #include <algorithm>

--- a/third_party/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp
+++ b/third_party/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp
@@ -25,7 +25,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
- #include "sora/fix_cuda_noinline_macro_error.h"
+#include "sora/fix_cuda_noinline_macro_error.h"
 
 #include <iostream>
 #include <algorithm>

--- a/third_party/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp
+++ b/third_party/NvCodec/NvCodec/NvDecoder/NvDecoder.cpp
@@ -25,7 +25,7 @@
  * OTHER DEALINGS IN THE SOFTWARE.
  */
 
-#include "sora/fix_cuda_noinline_macro_error.h"
+#include "sora/fix_cuda_noinline_macro_error.h"
 
 #include <iostream>
 #include <algorithm>

--- a/third_party/NvCodec/NvCodec/NvDecoder/NvDecoder.h
+++ b/third_party/NvCodec/NvCodec/NvDecoder/NvDecoder.h
@@ -1,13 +1,29 @@
 /*
-* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
-*
-* Please refer to the NVIDIA end user license agreement (EULA) associated
-* with this source code for terms and conditions that govern your use of
-* this software. Any use, reproduction, disclosure, or distribution of
-* this software and related documentation outside the terms of the EULA
-* is strictly prohibited.
-*
-*/
+ * This copyright notice applies to this header file only:
+ *
+ * Copyright (c) 2010-2023 NVIDIA Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the software, and to permit persons to whom the
+ * software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 #pragma once
 

--- a/third_party/NvCodec/NvCodec/NvEncoder/NvEncoder.cpp
+++ b/third_party/NvCodec/NvCodec/NvEncoder/NvEncoder.cpp
@@ -1,13 +1,29 @@
 /*
-* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
-*
-* Please refer to the NVIDIA end user license agreement (EULA) associated
-* with this source code for terms and conditions that govern your use of
-* this software. Any use, reproduction, disclosure, or distribution of
-* this software and related documentation outside the terms of the EULA
-* is strictly prohibited.
-*
-*/
+ * This copyright notice applies to this header file only:
+ *
+ * Copyright (c) 2010-2023 NVIDIA Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the software, and to permit persons to whom the
+ * software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 #include "NvEncoder/NvEncoder.h"
 
@@ -405,6 +421,12 @@ void NvEncoder::CreateEncoder(const NV_ENC_INITIALIZE_PARAMS* pEncoderParams)
             m_encodeConfig.rcParams.constQP = { 28, 31, 25 };
         }
     }
+
+    if (((uint32_t)m_encodeConfig.frameIntervalP) > m_encodeConfig.gopLength)
+    {
+        m_encodeConfig.frameIntervalP = m_encodeConfig.gopLength;
+    }
+
     m_initializeParams.encodeConfig = &m_encodeConfig;
 
     NVENC_API_CALL(m_nvenc.nvEncInitializeEncoder(m_hEncoder, &m_initializeParams));

--- a/third_party/NvCodec/NvCodec/NvEncoder/NvEncoder.h
+++ b/third_party/NvCodec/NvCodec/NvEncoder/NvEncoder.h
@@ -1,13 +1,29 @@
 /*
-* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
-*
-* Please refer to the NVIDIA end user license agreement (EULA) associated
-* with this source code for terms and conditions that govern your use of
-* this software. Any use, reproduction, disclosure, or distribution of
-* this software and related documentation outside the terms of the EULA
-* is strictly prohibited.
-*
-*/
+ * This copyright notice applies to this header file only:
+ *
+ * Copyright (c) 2010-2023 NVIDIA Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the software, and to permit persons to whom the
+ * software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 #pragma once
 
@@ -259,6 +275,11 @@ public:
     *  @brief This function returns the number of allocated buffers.
     */
     uint32_t GetEncoderBufferCount() const { return m_nEncoderBuffer; }
+
+    /*
+    * @brief This function returns initializeParams(width, height, fps etc).
+    */
+    NV_ENC_INITIALIZE_PARAMS GetinitializeParams() const { return m_initializeParams; }
 protected:
 
     /**

--- a/third_party/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.cpp
+++ b/third_party/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.cpp
@@ -1,13 +1,29 @@
 /*
-* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
-*
-* Please refer to the NVIDIA end user license agreement (EULA) associated
-* with this source code for terms and conditions that govern your use of
-* this software. Any use, reproduction, disclosure, or distribution of
-* this software and related documentation outside the terms of the EULA
-* is strictly prohibited.
-*
-*/
+ * This copyright notice applies to this header file only:
+ *
+ * Copyright (c) 2010-2023 NVIDIA Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the software, and to permit persons to whom the
+ * software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 #include "sora/fix_cuda_noinline_macro_error.h"
 

--- a/third_party/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.h
+++ b/third_party/NvCodec/NvCodec/NvEncoder/NvEncoderCuda.h
@@ -1,13 +1,29 @@
 /*
-* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
-*
-* Please refer to the NVIDIA end user license agreement (EULA) associated
-* with this source code for terms and conditions that govern your use of
-* this software. Any use, reproduction, disclosure, or distribution of
-* this software and related documentation outside the terms of the EULA
-* is strictly prohibited.
-*
-*/
+ * This copyright notice applies to this header file only:
+ *
+ * Copyright (c) 2010-2023 NVIDIA Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the software, and to permit persons to whom the
+ * software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 #pragma once
 

--- a/third_party/NvCodec/NvCodec/NvEncoder/NvEncoderD3D11.cpp
+++ b/third_party/NvCodec/NvCodec/NvEncoder/NvEncoderD3D11.cpp
@@ -1,13 +1,29 @@
 /*
-* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
-*
-* Please refer to the NVIDIA end user license agreement (EULA) associated
-* with this source code for terms and conditions that govern your use of
-* this software. Any use, reproduction, disclosure, or distribution of
-* this software and related documentation outside the terms of the EULA
-* is strictly prohibited.
-*
-*/
+ * This copyright notice applies to this header file only:
+ *
+ * Copyright (c) 2010-2023 NVIDIA Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the software, and to permit persons to whom the
+ * software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 
 #ifndef WIN32

--- a/third_party/NvCodec/NvCodec/NvEncoder/NvEncoderD3D11.h
+++ b/third_party/NvCodec/NvCodec/NvEncoder/NvEncoderD3D11.h
@@ -1,13 +1,29 @@
 /*
-* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
-*
-* Please refer to the NVIDIA end user license agreement (EULA) associated
-* with this source code for terms and conditions that govern your use of
-* this software. Any use, reproduction, disclosure, or distribution of
-* this software and related documentation outside the terms of the EULA
-* is strictly prohibited.
-*
-*/
+ * This copyright notice applies to this header file only:
+ *
+ * Copyright (c) 2010-2023 NVIDIA Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the software, and to permit persons to whom the
+ * software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 #pragma once
 

--- a/third_party/NvCodec/Utils/Logger.h
+++ b/third_party/NvCodec/Utils/Logger.h
@@ -1,13 +1,29 @@
 /*
-* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
-*
-* Please refer to the NVIDIA end user license agreement (EULA) associated
-* with this source code for terms and conditions that govern your use of
-* this software. Any use, reproduction, disclosure, or distribution of
-* this software and related documentation outside the terms of the EULA
-* is strictly prohibited.
-*
-*/
+ * This copyright notice applies to this header file only:
+ *
+ * Copyright (c) 2010-2023 NVIDIA Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the software, and to permit persons to whom the
+ * software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 #pragma once
 

--- a/third_party/NvCodec/Utils/NvCodecUtils.h
+++ b/third_party/NvCodec/Utils/NvCodecUtils.h
@@ -1,13 +1,29 @@
 /*
-* Copyright 2017-2022 NVIDIA Corporation.  All rights reserved.
-*
-* Please refer to the NVIDIA end user license agreement (EULA) associated
-* with this source code for terms and conditions that govern your use of
-* this software. Any use, reproduction, disclosure, or distribution of
-* this software and related documentation outside the terms of the EULA
-* is strictly prohibited.
-*
-*/
+ * This copyright notice applies to this header file only:
+ *
+ * Copyright (c) 2010-2023 NVIDIA Corporation
+ *
+ * Permission is hereby granted, free of charge, to any person
+ * obtaining a copy of this software and associated documentation
+ * files (the "Software"), to deal in the Software without
+ * restriction, including without limitation the rights to use,
+ * copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the software, and to permit persons to whom the
+ * software is furnished to do so, subject to the following
+ * conditions:
+ *
+ * The above copyright notice and this permission notice shall be
+ * included in all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+ * EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+ * OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+ * NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+ * HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+ * WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+ * OTHER DEALINGS IN THE SOFTWARE.
+ */
 
 //---------------------------------------------------------------------------
 //! \file NvCodecUtils.h
@@ -461,7 +477,7 @@ class ConcurrentQueue
 
 private:
     bool full() {
-        if (m_List.size() == maxSize)
+        if (maxSize > 0 && m_List.size() == maxSize)
             return true;
         return false;
     }

--- a/third_party/NvCodec/include/cuviddec.h
+++ b/third_party/NvCodec/include/cuviddec.h
@@ -1,7 +1,7 @@
 /*
  * This copyright notice applies to this header file only:
  *
- * Copyright (c) 2010-2022 NVIDIA Corporation
+ * Copyright (c) 2010-2023 NVIDIA Corporation
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation

--- a/third_party/NvCodec/include/nvEncodeAPI.h
+++ b/third_party/NvCodec/include/nvEncodeAPI.h
@@ -1,7 +1,7 @@
 /*
  * This copyright notice applies to this header file only:
  *
- * Copyright (c) 2010-2022 NVIDIA Corporation
+ * Copyright (c) 2010-2023 NVIDIA Corporation
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation
@@ -112,7 +112,7 @@ typedef void* NV_ENC_REGISTERED_PTR;        /**< A Resource that has been regist
 typedef void* NV_ENC_CUSTREAM_PTR;          /**< Pointer to CUstream*/
 
 #define NVENCAPI_MAJOR_VERSION 12
-#define NVENCAPI_MINOR_VERSION 0
+#define NVENCAPI_MINOR_VERSION 1
 
 #define NVENCAPI_VERSION (NVENCAPI_MAJOR_VERSION | (NVENCAPI_MINOR_VERSION << 24))
 
@@ -206,42 +206,6 @@ static const GUID NV_ENC_AV1_PROFILE_MAIN_GUID =
 // =========================================================================================
 // *   Preset GUIDS supported by the NvEncodeAPI interface.
 // =========================================================================================
-// {B2DFB705-4EBD-4C49-9B5F-24A777D3E587}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_DEFAULT_GUID =
-{ 0xb2dfb705, 0x4ebd, 0x4c49, { 0x9b, 0x5f, 0x24, 0xa7, 0x77, 0xd3, 0xe5, 0x87 } };
-
-// {60E4C59F-E846-4484-A56D-CD45BE9FDDF6}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_HP_GUID =
-{ 0x60e4c59f, 0xe846, 0x4484, { 0xa5, 0x6d, 0xcd, 0x45, 0xbe, 0x9f, 0xdd, 0xf6 } };
-
-// {34DBA71D-A77B-4B8F-9C3E-B6D5DA24C012}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_HQ_GUID =
-{ 0x34dba71d, 0xa77b, 0x4b8f, { 0x9c, 0x3e, 0xb6, 0xd5, 0xda, 0x24, 0xc0, 0x12 } };
-
-// {82E3E450-BDBB-4e40-989C-82A90DF9EF32}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_BD_GUID  =
-{ 0x82e3e450, 0xbdbb, 0x4e40, { 0x98, 0x9c, 0x82, 0xa9, 0xd, 0xf9, 0xef, 0x32 } };
-
-// {49DF21C5-6DFA-4feb-9787-6ACC9EFFB726}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOW_LATENCY_DEFAULT_GUID  =
-{ 0x49df21c5, 0x6dfa, 0x4feb, { 0x97, 0x87, 0x6a, 0xcc, 0x9e, 0xff, 0xb7, 0x26 } };
-
-// {C5F733B9-EA97-4cf9-BEC2-BF78A74FD105}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOW_LATENCY_HQ_GUID  =
-{ 0xc5f733b9, 0xea97, 0x4cf9, { 0xbe, 0xc2, 0xbf, 0x78, 0xa7, 0x4f, 0xd1, 0x5 } };
-
-// {67082A44-4BAD-48FA-98EA-93056D150A58}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOW_LATENCY_HP_GUID =
-{ 0x67082a44, 0x4bad, 0x48fa, { 0x98, 0xea, 0x93, 0x5, 0x6d, 0x15, 0xa, 0x58 } };
-
-// {D5BFB716-C604-44e7-9BB8-DEA5510FC3AC}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOSSLESS_DEFAULT_GUID =
-{ 0xd5bfb716, 0xc604, 0x44e7, { 0x9b, 0xb8, 0xde, 0xa5, 0x51, 0xf, 0xc3, 0xac } };
-
-// {149998E7-2364-411d-82EF-179888093409}
-NV_ENC_DEPRECATED static const GUID NV_ENC_PRESET_LOSSLESS_HP_GUID =
-{ 0x149998e7, 0x2364, 0x411d, { 0x82, 0xef, 0x17, 0x98, 0x88, 0x9, 0x34, 0x9 } };
-
 // Performance degrades and quality improves as we move from P1 to P7. Presets P3 to P7 for H264 and Presets P2 to P7 for HEVC have B frames enabled by default
 // for HIGH_QUALITY and LOSSLESS tuning info, and will not work with Weighted Prediction enabled. In case Weighted Prediction is required, disable B frames by
 // setting frameIntervalP = 1
@@ -296,10 +260,6 @@ typedef enum _NV_ENC_PARAMS_RC_MODE
     NV_ENC_PARAMS_RC_CONSTQP                = 0x0,       /**< Constant QP mode */
     NV_ENC_PARAMS_RC_VBR                    = 0x1,       /**< Variable bitrate mode */
     NV_ENC_PARAMS_RC_CBR                    = 0x2,       /**< Constant bitrate mode */
-    NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ        = 0x8,       /**< Deprecated, use NV_ENC_PARAMS_RC_CBR + NV_ENC_TWO_PASS_QUARTER_RESOLUTION / NV_ENC_TWO_PASS_FULL_RESOLUTION +
-                                                              lowDelayKeyFrameScale=1 */
-    NV_ENC_PARAMS_RC_CBR_HQ                 = 0x10,      /**< Deprecated, use NV_ENC_PARAMS_RC_CBR + NV_ENC_TWO_PASS_QUARTER_RESOLUTION / NV_ENC_TWO_PASS_FULL_RESOLUTION */
-    NV_ENC_PARAMS_RC_VBR_HQ                 = 0x20       /**< Deprecated, use NV_ENC_PARAMS_RC_VBR + NV_ENC_TWO_PASS_QUARTER_RESOLUTION / NV_ENC_TWO_PASS_FULL_RESOLUTION */
 } NV_ENC_PARAMS_RC_MODE;
 
 /**
@@ -311,6 +271,25 @@ typedef enum _NV_ENC_MULTI_PASS
     NV_ENC_TWO_PASS_QUARTER_RESOLUTION      = 0x1,        /**< Two Pass encoding is enabled where first Pass is quarter resolution */
     NV_ENC_TWO_PASS_FULL_RESOLUTION         = 0x2,        /**< Two Pass encoding is enabled where first Pass is full resolution */
 } NV_ENC_MULTI_PASS;
+
+/**
+ * Restore Encoder state
+ */
+typedef enum _NV_ENC_STATE_RESTORE_TYPE
+{
+    NV_ENC_STATE_RESTORE_FULL               = 0x01,      /**< Restore full encoder state */
+    NV_ENC_STATE_RESTORE_RATE_CONTROL       = 0x02,      /**< Restore only rate control state */
+    NV_ENC_STATE_RESTORE_ENCODE             = 0x03,      /**< Restore full encoder state except for rate control state */
+} NV_ENC_STATE_RESTORE_TYPE;
+
+typedef enum _NV_ENC_OUTPUT_STATS_LEVEL
+{
+    NV_ENC_OUTPUT_STATS_NONE          = 0,             /** No output stats */
+    NV_ENC_OUTPUT_STATS_BLOCK_LEVEL   = 1,             /** Output stats for every block. 
+                                                           Block represents a CTB for HEVC, macroblock for H.264, super block for AV1 */
+    NV_ENC_OUTPUT_STATS_ROW_LEVEL     = 2,             /** Output stats for every row. 
+                                                           Row represents a CTB row for HEVC, macroblock row for H.264, super block row for AV1 */
+} NV_ENC_OUTPUT_STATS_LEVEL;
 
 /**
  * Emphasis Levels
@@ -335,12 +314,6 @@ typedef enum _NV_ENC_QP_MAP_MODE
     NV_ENC_QP_MAP_DELTA                  = 0x2,             /**< Value in NV_ENC_PIC_PARAMS::qpDeltaMap will be treated as QP delta map. */
     NV_ENC_QP_MAP                        = 0x3,             /**< Currently This is not supported. Value in NV_ENC_PIC_PARAMS::qpDeltaMap will be treated as QP value.   */
 } NV_ENC_QP_MAP_MODE;
-
-#define NV_ENC_PARAMS_RC_VBR_MINQP              (NV_ENC_PARAMS_RC_MODE)0x4          /**< Deprecated */
-#define NV_ENC_PARAMS_RC_2_PASS_QUALITY         NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ    /**< Deprecated */
-#define NV_ENC_PARAMS_RC_2_PASS_FRAMESIZE_CAP   NV_ENC_PARAMS_RC_CBR_HQ             /**< Deprecated */
-#define NV_ENC_PARAMS_RC_2_PASS_VBR             NV_ENC_PARAMS_RC_VBR_HQ             /**< Deprecated */
-#define NV_ENC_PARAMS_RC_CBR2                   NV_ENC_PARAMS_RC_CBR                /**< Deprecated */
 
 /**
  * Input picture structure
@@ -682,6 +655,16 @@ typedef enum _NVENCSTATUS
      * that has not been successfully mapped.
      */
     NV_ENC_ERR_RESOURCE_NOT_MAPPED,
+    
+    /**
+     * This indicates encode driver requires more output buffers to write an output
+     * bitstream. If this error is returned from ::NvEncRestoreEncoderState() API, this
+     * is not a fatal error. If the client is encoding with B frames then,
+     * ::NvEncRestoreEncoderState() API might be requiring the extra output buffer for accomodating overlay frame output in a separate buffer, for AV1 codec.
+     * In this case, client must call NvEncRestoreEncoderState() API again with NV_ENC_RESTORE_ENCODER_STATE_PARAMS::outputBitstream as input along with 
+     * the parameters in the previous call. When operating in asynchronous mode of encoding, client must also specify NV_ENC_RESTORE_ENCODER_STATE_PARAMS::completionEvent.
+     */
+    NV_ENC_ERR_NEED_MORE_OUTPUT,
 
 } NVENCSTATUS;
 
@@ -696,6 +679,8 @@ typedef enum _NV_ENC_PIC_FLAGS
                                                      [_NV_ENC_INITIALIZE_PARAMS::enablePTD == 1]. */
     NV_ENC_PIC_FLAG_OUTPUT_SPSPPS      = 0x4,   /**< Write the sequence and picture header in encoded bitstream of the current picture */
     NV_ENC_PIC_FLAG_EOS                = 0x8,   /**< Indicates end of the input stream */
+    NV_ENC_PIC_FLAG_DISABLE_ENC_STATE_ADVANCE = 0x10,  /**< Do not advance encoder state during encode */ 
+    NV_ENC_PIC_FLAG_OUTPUT_RECON_FRAME        = 0x20,  /**< Write reconstructed frame */ 
 } NV_ENC_PIC_FLAGS;
 
 /**
@@ -796,6 +781,7 @@ typedef enum _NV_ENC_BUFFER_USAGE
     NV_ENC_OUTPUT_MOTION_VECTOR     = 0x1,          /**< Registered surface will be used for output of H.264 ME only mode.
                                                          This buffer usage type is not supported for HEVC ME only mode. */
     NV_ENC_OUTPUT_BITSTREAM         = 0x2,          /**< Registered surface will be used for output bitstream in encoding */
+    NV_ENC_OUTPUT_RECON             = 0x4,          /**< Registered surface will be used for output reconstructed frame in encoding */
 } NV_ENC_BUFFER_USAGE;
 
 /**
@@ -1176,6 +1162,26 @@ typedef enum _NV_ENC_CAPS
      */
     NV_ENC_CAPS_SINGLE_SLICE_INTRA_REFRESH,
 
+    /**
+     * Indicates encoding without advancing the state support.
+     */
+    NV_ENC_CAPS_DISABLE_ENC_STATE_ADVANCE,
+
+    /**
+     * Indicates reconstructed output support.
+     */
+    NV_ENC_CAPS_OUTPUT_RECON_SURFACE,
+
+    /**
+     * Indicates encoded frame output stats support for every block. Block represents a CTB for HEVC, macroblock for H.264 and super block for AV1.
+     */
+    NV_ENC_CAPS_OUTPUT_BLOCK_STATS,
+
+    /**
+     * Indicates encoded frame output stats support for every row. Row represents a CTB row for HEVC, macroblock row for H.264 and super block row for AV1.
+     */
+    NV_ENC_CAPS_OUTPUT_ROW_STATS,
+
      /**
      * Reserved - Not to be used by clients.
      */
@@ -1293,6 +1299,55 @@ typedef struct _NV_ENC_CAPS_PARAM
 
 
 /**
+ * Restore encoder state parameters
+ */
+typedef struct _NV_ENC_RESTORE_ENCODER_STATE_PARAMS
+{
+    uint32_t                  version;                 /**< [in]: Struct version. */
+    uint32_t                  bufferIdx;               /**< [in]: State buffer index to which the encoder state will be restored */
+    NV_ENC_STATE_RESTORE_TYPE state;                   /**< [in]: State type to restore */
+    NV_ENC_OUTPUT_PTR         outputBitstream;         /**< [in]: Specifies the output buffer pointer, for AV1 encode only. 
+                                                                  Application must call NvEncRestoreEncoderState() API with _NV_ENC_RESTORE_ENCODER_STATE_PARAMS::outputBitstream and 
+                                                                  _NV_ENC_RESTORE_ENCODER_STATE_PARAMS::completionEvent as input when an earlier call to this API returned "NV_ENC_ERR_NEED_MORE_OUTPUT", for AV1 encode. */
+    void*                     completionEvent;         /**< [in]: Specifies the completion event when asynchronous mode of encoding is enabled. Used for AV1 encode only. */
+    uint32_t                  reserved1[64];           /**< [in]: Reserved and must be set to 0 */
+    void*                     reserved2[64];           /**< [in]: Reserved and must be set to NULL */
+} NV_ENC_RESTORE_ENCODER_STATE_PARAMS;
+
+/** NV_ENC_RESTORE_ENCODER_STATE_PARAMS struct version. */
+#define NV_ENC_RESTORE_ENCODER_STATE_PARAMS_VER NVENCAPI_STRUCT_VERSION(1)
+
+/**
+ * Encoded frame information parameters for every block.
+ */
+typedef struct _NV_ENC_OUTPUT_STATS_BLOCK
+{
+   uint32_t                 version;                /**< [in]: Struct version */
+   uint8_t                  QP;                     /**< [out]: QP of the block */
+   uint8_t                  reserved[3];            /**< [in]: Reserved and must be set to 0 */
+   uint32_t                 bitcount;               /**< [out]: Bitcount of the block */
+   uint32_t                 reserved1[13];          /**< [in]: Reserved and must be set to 0 */
+} NV_ENC_OUTPUT_STATS_BLOCK;
+
+/** NV_ENC_OUTPUT_STATS_BLOCK struct version. */
+#define NV_ENC_OUTPUT_STATS_BLOCK_VER NVENCAPI_STRUCT_VERSION(1)
+
+/**
+ * Encoded frame information parameters for every row.
+ */
+typedef struct _NV_ENC_OUTPUT_STATS_ROW
+{
+   uint32_t                 version;                /**< [in]: Struct version */
+   uint8_t                  QP;                     /**< [out]: QP of the row */
+   uint8_t                  reserved[3];            /**< [in]: Reserved and must be set to 0 */
+   uint32_t                 bitcount;               /**< [out]: Bitcount of the row */
+   uint32_t                 reserved1[13];          /**< [in]: Reserved and must be set to 0 */
+} NV_ENC_OUTPUT_STATS_ROW;
+
+/** NV_ENC_OUTPUT_STATS_ROW struct version. */
+#define NV_ENC_OUTPUT_STATS_ROW_VER NVENCAPI_STRUCT_VERSION(1)
+
+/**
  * Encoder Output parameters
  */
 typedef struct _NV_ENC_ENCODE_OUT_PARAMS
@@ -1304,6 +1359,21 @@ typedef struct _NV_ENC_ENCODE_OUT_PARAMS
 
 /** NV_ENC_ENCODE_OUT_PARAMS struct version. */
 #define NV_ENC_ENCODE_OUT_PARAMS_VER NVENCAPI_STRUCT_VERSION(1)
+
+/**
+ * Lookahead picture parameters
+ */
+typedef struct _NV_ENC_LOOKAHEAD_PIC_PARAMS
+{
+    uint32_t                  version;                 /**< [in]: Struct version. */
+    NV_ENC_INPUT_PTR          inputBuffer;             /**< [in]: Specifies the input buffer pointer. Client must use a pointer obtained from ::NvEncCreateInputBuffer() or ::NvEncMapInputResource() APIs.*/
+    NV_ENC_PIC_TYPE           pictureType;             /**< [in]: Specifies input picture type. Client required to be set explicitly by the client if the client has not set NV_ENC_INITALIZE_PARAMS::enablePTD to 1 while calling NvInitializeEncoder. */
+    uint32_t                  reserved[64];            /**< [in]: Reserved and must be set to 0 */
+    void*                     reserved1[64];           /**< [in]: Reserved and must be set to NULL */
+} NV_ENC_LOOKAHEAD_PIC_PARAMS;
+
+/** NV_ENC_LOOKAHEAD_PIC_PARAMS struct version. */
+#define NV_ENC_LOOKAHEAD_PIC_PARAMS_VER NVENCAPI_STRUCT_VERSION(1)
 
 /**
  * Creation parameters for input buffer.
@@ -1428,10 +1498,14 @@ typedef struct _NV_ENC_QP
     uint32_t                        strictGOPTarget      :1;                     /**< [in]: Set this to 1 to minimize GOP-to-GOP rate fluctuations */
     uint32_t                        aqStrength           :4;                     /**< [in]: When AQ (Spatial) is enabled (i.e. NV_ENC_RC_PARAMS::enableAQ is set), this field is used to specify AQ strength. AQ strength scale is from 1 (low) - 15 (aggressive).
                                                                                             If not set, strength is auto selected by driver. */
-    uint32_t                        reservedBitFields    :16;                    /**< [in]: Reserved bitfields and must be set to 0 */
+    uint32_t                        enableExtLookahead   :1;                     /**< [in]: Set this to 1 to enable lookahead externally. 
+                                                                                            Application must call NvEncLookahead() for NV_ENC_RC_PARAMS::lookaheadDepth number of frames,
+                                                                                            before calling NvEncEncodePicture() for the first frame */
+    uint32_t                        reservedBitFields    :15;                    /**< [in]: Reserved bitfields and must be set to 0 */
     NV_ENC_QP                       minQP;                                       /**< [in]: Specifies the minimum QP used for rate control. Client must set NV_ENC_CONFIG::enableMinQP to 1. */
     NV_ENC_QP                       maxQP;                                       /**< [in]: Specifies the maximum QP used for rate control. Client must set NV_ENC_CONFIG::enableMaxQP to 1. */
-    NV_ENC_QP                       initialRCQP;                                 /**< [in]: Specifies the initial QP used for rate control. Client must set NV_ENC_CONFIG::enableInitialRCQP to 1. */
+    NV_ENC_QP                       initialRCQP;                                 /**< [in]: Specifies the initial QP hint used for rate control. The parameter is just used as hint to influence the QP difference between I,P and B frames.
+                                                                                            Client must set NV_ENC_CONFIG::enableInitialRCQP to 1. */
     uint32_t                        temporallayerIdxMask;                        /**< [in]: Specifies the temporal layers (as a bitmask) whose QPs have changed. Valid max bitmask is [2^NV_ENC_CAPS_NUM_MAX_TEMPORAL_LAYERS - 1].
                                                                                             Applicable only for constant QP mode (NV_ENC_RC_PARAMS::rateControlMode = NV_ENC_PARAMS_RC_CONSTQP). */
     uint8_t                         temporalLayerQP[8];                          /**< [in]: Specifies the temporal layer QPs used for rate control. Temporal layer index is used as the array index.
@@ -1618,9 +1692,7 @@ typedef struct _NV_ENC_CONFIG_H264
                                                                                Check support for lossless encoding using ::NV_ENC_CAPS_SUPPORT_LOSSLESS_ENCODE caps.  */
     uint32_t useConstrainedIntraPred   :1;                          /**< [in]: Set 1 to enable constrained intra prediction. */
     uint32_t enableFillerDataInsertion :1;                          /**< [in]: Set to 1 to enable insertion of filler data in the bitstream.
-                                                                               This flag will take effect only when one of the CBR rate
-                                                                               control modes (NV_ENC_PARAMS_RC_CBR, NV_ENC_PARAMS_RC_CBR_HQ,
-                                                                               NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ) is in use and both
+                                                                               This flag will take effect only when CBR rate control mode is in use and both
                                                                                NV_ENC_INITIALIZE_PARAMS::frameRateNum and
                                                                                NV_ENC_INITIALIZE_PARAMS::frameRateDen are set to non-zero
                                                                                values. Setting this field when
@@ -1719,9 +1791,7 @@ typedef struct _NV_ENC_CONFIG_HEVC
     uint32_t chromaFormatIDC                       :2;              /**< [in]: Specifies the chroma format. Should be set to 1 for yuv420 input, 3 for yuv444 input.*/
     uint32_t pixelBitDepthMinus8                   :3;              /**< [in]: Specifies pixel bit depth minus 8. Should be set to 0 for 8 bit input, 2 for 10 bit input.*/
     uint32_t enableFillerDataInsertion             :1;              /**< [in]: Set to 1 to enable insertion of filler data in the bitstream.
-                                                                               This flag will take effect only when one of the CBR rate
-                                                                               control modes (NV_ENC_PARAMS_RC_CBR, NV_ENC_PARAMS_RC_CBR_HQ,
-                                                                               NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ) is in use and both
+                                                                               This flag will take effect only when CBR rate control mode is in use and both
                                                                                NV_ENC_INITIALIZE_PARAMS::frameRateNum and
                                                                                NV_ENC_INITIALIZE_PARAMS::frameRateDen are set to non-zero
                                                                                values. Setting this field when
@@ -1957,6 +2027,18 @@ typedef enum NV_ENC_TUNING_INFO
 }NV_ENC_TUNING_INFO;
 
 /**
+ * Split Encoding Modes (Split Encoding is not applicable to H264).
+ */
+typedef enum _NV_ENC_SPLIT_ENCODE_MODE
+{
+    NV_ENC_SPLIT_AUTO_MODE               = 0,                                    /**< Default value, split frame forced mode disabled, split frame auto mode enabled */
+    NV_ENC_SPLIT_AUTO_FORCED_MODE        = 1,                                    /**< Split frame forced mode enabled with number of strips automatically selected by driver to best fit configuration */
+    NV_ENC_SPLIT_TWO_FORCED_MODE         = 2,                                    /**< Forced 2-strip split frame encoding (if NVENC number > 1, 1-strip encode otherwise) */
+    NV_ENC_SPLIT_THREE_FORCED_MODE       = 3,                                    /**< Forced 3-strip split frame encoding (if NVENC number > 2, NVENC number of strips otherwise) */
+    NV_ENC_SPLIT_DISABLE_MODE            = 15,                                   /**< Both split frame auto mode and forced mode are disabled  */
+} NV_ENC_SPLIT_ENCODE_MODE;
+
+/**
  * \struct _NV_ENC_INITIALIZE_PARAMS
  * Encode Session Initialization parameters.
  */
@@ -1983,13 +2065,21 @@ typedef struct _NV_ENC_INITIALIZE_PARAMS
     uint32_t                                   enableMEOnlyMode          :1;    /**< [in]: Set to 1 to enable ME Only Mode .*/
     uint32_t                                   enableWeightedPrediction  :1;    /**< [in]: Set this to 1 to enable weighted prediction. Not supported if encode session is configured for B-Frames (i.e. NV_ENC_CONFIG::frameIntervalP > 1 or preset >=P3 when tuningInfo = ::NV_ENC_TUNING_INFO_HIGH_QUALITY or
                                                                                            tuningInfo = ::NV_ENC_TUNING_INFO_LOSSLESS. This is because preset >=p3 internally enables B frames when tuningInfo = ::NV_ENC_TUNING_INFO_HIGH_QUALITY or ::NV_ENC_TUNING_INFO_LOSSLESS). */
+    uint32_t                                   splitEncodeMode           :4;    /**< [in]: Split Encoding mode in NVENC (Split Encoding is not applicable to H264).
+                                                                                           Not supported if any of the following features: weighted prediction, alpha layer encoding,
+                                                                                           subframe mode, output into video memory buffer, picture timing/buffering period SEI message
+                                                                                           insertion with DX12 interface are enabled in case of HEVC.
+                                                                                           For AV1, split encoding is not supported when output into video memory buffer is enabled. */
     uint32_t                                   enableOutputInVidmem      :1;    /**< [in]: Set this to 1 to enable output of NVENC in video memory buffer created by application. This feature is not supported for HEVC ME only mode. */
-    uint32_t                                   reservedBitFields         :26;   /**< [in]: Reserved bitfields and must be set to 0 */
+    uint32_t                                   enableReconFrameOutput    :1;    /**< [in]: Set this to 1 to enable reconstructed frame output. */
+    uint32_t                                   enableOutputStats         :1;    /**< [in]: Set this to 1 to enable encoded frame output stats. Client must allocate buffer of size equal to number of blocks multiplied by the size of
+                                                                                           NV_ENC_OUTPUT_STATS_BLOCK struct in system memory and assign to NV_ENC_LOCK_BITSTREAM::encodedOutputStatsPtr to receive the encoded frame output stats.*/
+    uint32_t                                   reservedBitFields         :20;   /**< [in]: Reserved bitfields and must be set to 0 */
     uint32_t                                   privDataSize;                    /**< [in]: Reserved private data buffer size and must be set to 0 */
     void*                                      privData;                        /**< [in]: Reserved private data buffer and must be set to NULL */
     NV_ENC_CONFIG*                             encodeConfig;                    /**< [in]: Specifies the advanced codec specific structure. If client has sent a valid codec config structure, it will override parameters set by the NV_ENC_INITIALIZE_PARAMS::presetGUID parameter. If set to NULL the NvEncodeAPI interface will use the NV_ENC_INITIALIZE_PARAMS::presetGUID to set the codec specific parameters.
-                                                                                           Client can also optionally query the NvEncodeAPI interface to get codec specific parameters for a presetGUID using ::NvEncGetEncodePresetConfig() API. It can then modify (if required) some of the codec config parameters and send down a custom config structure as part of ::_NV_ENC_INITIALIZE_PARAMS.
-                                                                                           Even in this case client is recommended to pass the same preset guid it has used in ::NvEncGetEncodePresetConfig() API to query the config structure; as NV_ENC_INITIALIZE_PARAMS::presetGUID. This will not override the custom config structure but will be used to determine other Encoder HW specific parameters not exposed in the API. */
+                                                                                           Client can also optionally query the NvEncodeAPI interface to get codec specific parameters for a presetGUID using ::NvEncGetEncodePresetConfigEx() API. It can then modify (if required) some of the codec config parameters and send down a custom config structure as part of ::_NV_ENC_INITIALIZE_PARAMS.
+                                                                                           Even in this case client is recommended to pass the same preset guid it has used in ::NvEncGetEncodePresetConfigEx() API to query the config structure; as NV_ENC_INITIALIZE_PARAMS::presetGUID. This will not override the custom config structure but will be used to determine other Encoder HW specific parameters not exposed in the API. */
     uint32_t                                   maxEncodeWidth;                  /**< [in]: Maximum encode width to be used for current Encode session.
                                                                                            Client should allocate output buffers according to this dimension for dynamic resolution change. If set to 0, Encoder will not allow dynamic resolution change. */
     uint32_t                                   maxEncodeHeight;                 /**< [in]: Maximum encode height to be allowed for current Encode session.
@@ -1999,12 +2089,18 @@ typedef struct _NV_ENC_INITIALIZE_PARAMS
                                                                                            This client must also set NV_ENC_INITIALIZE_PARAMS::enableExternalMEHints to 1. */
     NV_ENC_TUNING_INFO                         tuningInfo;                      /**< [in]: Tuning Info of NVENC encoding(TuningInfo is not applicable to H264 and HEVC meonly mode). */
     NV_ENC_BUFFER_FORMAT                       bufferFormat;                    /**< [in]: Input buffer format. Used only when DX12 interface type is used */
-    uint32_t                                   reserved [287];                  /**< [in]: Reserved and must be set to 0 */
+    uint32_t                                   numStateBuffers;                 /**< [in]: Number of state buffers to allocate to save encoder state. Set this to value greater than zero to enable encoding without advancing the encoder state. */
+    NV_ENC_OUTPUT_STATS_LEVEL                  outputStatsLevel;                /**< [in]: Specifies the level for encoded frame output stats, when NV_ENC_INITIALIZE_PARAMS::enableOutputStats is set to 1.
+                                                                                           Client should allocate buffer of size equal to number of blocks multiplied by the size of NV_ENC_OUTPUT_STATS_BLOCK struct
+                                                                                           if NV_ENC_INITIALIZE_PARAMS::outputStatsLevel is set to NV_ENC_OUTPUT_STATS_BLOCK or number of rows multiplied by the size of 
+                                                                                           NV_ENC_OUTPUT_STATS_ROW struct if NV_ENC_INITIALIZE_PARAMS::outputStatsLevel is set to NV_ENC_OUTPUT_STATS_ROW
+                                                                                           in system memory and assign to NV_ENC_LOCK_BITSTREAM::encodedOutputStatsPtr to receive the encoded frame output stats. */
+    uint32_t                                   reserved [285];                  /**< [in]: Reserved and must be set to 0 */
     void*                                      reserved2[64];                   /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_INITIALIZE_PARAMS;
 
 /** macro for constructing the version field of ::_NV_ENC_INITIALIZE_PARAMS */
-#define NV_ENC_INITIALIZE_PARAMS_VER (NVENCAPI_STRUCT_VERSION(5) | ( 1<<31 ))
+#define NV_ENC_INITIALIZE_PARAMS_VER (NVENCAPI_STRUCT_VERSION(6) | ( 1<<31 ))
 
 
 /**
@@ -2301,8 +2397,16 @@ typedef struct _NV_ENC_PIC_PARAMS
     uint32_t                                    meSbHintsCount;                  /**< [in]: For AV1, specifies the total number of external ME SB hint candidates for the frame
                                                                                             NV_ENC_PIC_PARAMS::meSbHintsCount must never exceed the total number of SBs in frame * the max number of candidates per SB provided during encoder initialization.
                                                                                             The max number of candidates per SB is maxMeHintCountsPerBlock[0].numCandsPerSb + maxMeHintCountsPerBlock[1].numCandsPerSb */
-    uint32_t                                    reserved3[285];                  /**< [in]: Reserved and must be set to 0 */
-    void*                                       reserved4[58];                   /**< [in]: Reserved and must be set to NULL */
+    uint32_t                                    stateBufferIdx;                  /**< [in]: Specifies the buffer index in which the encoder state will be saved for current frame encode. It must be in the 
+                                                                                            range 0 to NV_ENC_INITIALIZE_PARAMS::numStateBuffers - 1. */
+    NV_ENC_OUTPUT_PTR                           outputReconBuffer;               /**< [in]: Specifies the reconstructed frame buffer pointer to output reconstructed frame, if enabled by setting NV_ENC_INITIALIZE_PARAMS::enableReconFrameOutput.
+                                                                                            Client must allocate buffers for writing the reconstructed frames and register them with the Nvidia Video Encoder Interface with NV_ENC_REGISTER_RESOURCE::bufferUsage
+                                                                                            set to NV_ENC_OUTPUT_RECON. 
+                                                                                            Client must use the pointer obtained from ::NvEncMapInputResource() API and assign it to NV_ENC_PIC_PARAMS::outputReconBuffer.
+                                                                                            Reconstructed output will be in NV_ENC_BUFFER_FORMAT_NV12 format when chromaFormatIDC is set to 1.
+                                                                                            chromaFormatIDC = 3 is not supported. */
+    uint32_t                                    reserved3[284];                  /**< [in]: Reserved and must be set to 0 */    
+    void*                                       reserved4[57];                   /**< [in]: Reserved and must be set to NULL */
 } NV_ENC_PIC_PARAMS;
 
 /** Macro for constructing the version field of ::_NV_ENC_PIC_PARAMS */
@@ -2378,19 +2482,20 @@ typedef struct _NV_ENC_LOCK_BITSTREAM
     uint32_t                ltrFrameIdx;                 /**< [out]: Frame index associated with this LTR frame. */
     uint32_t                ltrFrameBitmap;              /**< [out]: Bitmap of LTR frames indices which were used for encoding this frame. Value of 0 if no LTR frames were used. */
     uint32_t                temporalId;                  /**< [out]: TemporalId value of the frame when using temporalSVC encoding */
-    uint32_t                reserved[12];                /**< [in]: Reserved and must be set to 0 */
     uint32_t                intraMBCount;                /**< [out]: For H264, Number of Intra MBs in the encoded frame. For HEVC, Number of Intra CTBs in the encoded frame. For AV1, Number of Intra SBs in the encoded show frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
     uint32_t                interMBCount;                /**< [out]: For H264, Number of Inter MBs in the encoded frame, includes skip MBs. For HEVC, Number of Inter CTBs in the encoded frame. For AV1, Number of Inter SBs in the encoded show frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
     int32_t                 averageMVX;                  /**< [out]: Average Motion Vector in X direction for the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
     int32_t                 averageMVY;                  /**< [out]: Average Motion Vector in y direction for the encoded frame. Supported only if _NV_ENC_LOCK_BITSTREAM::getRCStats set to 1. */
     uint32_t                alphaLayerSizeInBytes;       /**< [out]: Number of bytes generated for the alpha layer in the encoded output. Applicable only when HEVC with alpha encoding is enabled. */
-
-    uint32_t                reserved1[218];              /**< [in]: Reserved and must be set to 0 */
-    void*                   reserved2[64];               /**< [in]: Reserved and must be set to NULL */
+    uint32_t                outputStatsPtrSize;          /**< [in]: Size of the buffer pointed by NV_ENC_LOCK_BITSTREAM::outputStatsPtr. */
+    void*                   outputStatsPtr;              /**< [in, out]: Buffer which receives the encoded frame output stats, if NV_ENC_INITIALIZE_PARAMS::enableOutputStats is set to 1. */
+    uint32_t                frameIdxDisplay;             /**< [out]: Frame index in display order */
+    uint32_t                reserved1[220];              /**< [in]: Reserved and must be set to 0 */
+    void*                   reserved2[63];               /**< [in]: Reserved and must be set to NULL */
+    uint32_t                reservedInternal[8];         /**< [in]: Reserved and must be set to 0 */
 } NV_ENC_LOCK_BITSTREAM;
 
-/** Macro for constructing the version field of ::_NV_ENC_LOCK_BITSTREAM */
-#define NV_ENC_LOCK_BITSTREAM_VER NVENCAPI_STRUCT_VERSION(2)
+#define NV_ENC_LOCK_BITSTREAM_VER (NVENCAPI_STRUCT_VERSION(1) | ( 1<<31 ))
 
 
 /**
@@ -2535,7 +2640,11 @@ typedef struct _NV_ENC_REGISTER_RESOURCE
                                                                            before starting GPU operation, if NV_ENC_FENCE_POINT_D3D12::bWait is set.
                                                                            The fence NV_ENC_FENCE_POINT_D3D12::pFence and NV_ENC_FENCE_POINT_D3D12::signalValue will be used to do GPU signal
                                                                            when GPU operation finishes, if NV_ENC_FENCE_POINT_D3D12::bSignal is set. */
-    uint32_t                    reserved1[247];                 /**< [in]: Reserved and must be set to 0. */
+    uint32_t                    chromaOffset[2];                /**< [out]: Chroma offset for the reconstructed output buffer when NV_ENC_BUFFER_USAGE::bufferUsage is set 
+                                                                           to NV_ENC_OUTPUT_RECON and D3D11 interface is used. 
+                                                                           When chroma components are interleaved, 'chromaOffset[0]' will contain chroma offset. 
+                                                                           chromaOffset[1] is reserved for future use. */
+    uint32_t                    reserved1[245];                 /**< [in]: Reserved and must be set to 0. */
     void*                       reserved2[61];                  /**< [in]: Reserved and must be set to NULL. */
 } NV_ENC_REGISTER_RESOURCE;
 
@@ -3531,6 +3640,34 @@ NVENCSTATUS NVENCAPI NvEncLockBitstream                         (void* encoder, 
  */
 NVENCSTATUS NVENCAPI NvEncUnlockBitstream                       (void* encoder, NV_ENC_OUTPUT_PTR bitstreamBuffer);
 
+// NvEncRestoreEncoderState
+/**
+ * \brief Restore state of encoder
+ *
+ * This function is used to restore the state of encoder with state saved internally in
+ * state buffer corresponding to index equal to 'NV_ENC_RESTORE_ENCODER_STATE_PARAMS::bfrIndex'. 
+ * Client can specify the state type to be updated by specifying appropriate value in
+ * 'NV_ENC_RESTORE_ENCODER_STATE_PARAMS::state'. The client must call this 
+ * function after all previous encodes have finished.
+ *
+ * \param [in] encoder
+ *   Pointer to the NvEncodeAPI interface.
+ * \param [in] restoreState
+ *   Pointer to the ::_NV_ENC_RESTORE_ENCODER_STATE_PARAMS structure
+ *
+ * \return
+ * ::NV_ENC_SUCCESS \n
+ * ::NV_ENC_ERR_INVALID_PTR \n
+ * ::NV_ENC_ERR_INVALID_ENCODERDEVICE \n
+ * ::NV_ENC_ERR_DEVICE_NOT_EXIST \n
+ * ::NV_ENC_ERR_UNSUPPORTED_PARAM \n
+ * ::NV_ENC_ERR_OUT_OF_MEMORY \n
+ * ::NV_ENC_ERR_INVALID_PARAM \n
+ * ::NV_ENC_ERR_ENCODER_NOT_INITIALIZED \n
+ * ::NV_ENC_ERR_GENERIC \n
+ *
+ */
+NVENCSTATUS NVENCAPI NvEncRestoreEncoderState                    (void* encoder, NV_ENC_RESTORE_ENCODER_STATE_PARAMS* restoreState);
 
 // NvLockInputBuffer
 /**
@@ -4146,6 +4283,32 @@ NVENCSTATUS NVENCAPI NvEncodeAPIGetMaxSupportedVersion          (uint32_t* versi
  */
 const char * NVENCAPI NvEncGetLastErrorString          (void* encoder);
 
+// NvEncLookaheadPicture
+/**
+ * \brief Submit an input picture for lookahead.
+ *
+ * This function can be used by clients to submit input frame for lookahead. Client could call this function 
+ * NV_ENC_INITIALIZE_PARAMS::lookaheadDepth plus one number of frames, before calling NvEncEncodePicture() for the first frame.
+ *
+ * \param [in] encoder
+ *   Pointer to the NvEncodeAPI interface.
+ * \param [in] lookaheadParams
+ *   Pointer to the ::_NV_ENC_LOOKAHEAD_PIC_PARAMS structure.
+ *
+ * \return
+ * ::NV_ENC_SUCCESS \n
+ * ::NV_ENC_NEED_MORE_INPUT \n  should we return this error is lookahead queue is not full? 
+ * ::NV_ENC_ERR_INVALID_PTR \n
+ * ::NV_ENC_ERR_ENCODER_NOT_INITIALIZED \n
+ * ::NV_ENC_ERR_GENERIC \n
+ * ::NV_ENC_ERR_INVALID_ENCODERDEVICE \n
+ * ::NV_ENC_ERR_DEVICE_NOT_EXIST \n
+ * ::NV_ENC_ERR_UNSUPPORTED_PARAM \n
+ * ::NV_ENC_ERR_OUT_OF_MEMORY \n
+ * ::NV_ENC_ERR_INVALID_PARAM \n
+ * ::NV_ENC_ERR_INVALID_VERSION \n
+ */
+NVENCSTATUS NVENCAPI NvEncLookaheadPicture          (void* encoder, NV_ENC_LOOKAHEAD_PIC_PARAMS *lookaheadParamas);
 
 /// \cond API PFN
 /*
@@ -4192,6 +4355,8 @@ typedef NVENCSTATUS (NVENCAPI* PNVENCRUNMOTIONESTIMATIONONLY)   (void* encoder, 
 typedef const char * (NVENCAPI* PNVENCGETLASTERROR)             (void* encoder);
 typedef NVENCSTATUS (NVENCAPI* PNVENCSETIOCUDASTREAMS)          (void* encoder, NV_ENC_CUSTREAM_PTR inputStream, NV_ENC_CUSTREAM_PTR outputStream);
 typedef NVENCSTATUS (NVENCAPI* PNVENCGETSEQUENCEPARAMEX)        (void* encoder, NV_ENC_INITIALIZE_PARAMS* encInitParams, NV_ENC_SEQUENCE_PARAM_PAYLOAD* sequenceParamPayload);
+typedef NVENCSTATUS (NVENCAPI* PNVENCRESTOREENCODERSTATE)       (void* encoder, NV_ENC_RESTORE_ENCODER_STATE_PARAMS* restoreState);
+typedef NVENCSTATUS (NVENCAPI* PNVENCLOOKAHEADPICTURE)          (void* encoder, NV_ENC_LOOKAHEAD_PIC_PARAMS* lookaheadParams);
 
 
 /// \endcond
@@ -4248,7 +4413,9 @@ typedef struct _NV_ENCODE_API_FUNCTION_LIST
     PNVENCSETIOCUDASTREAMS          nvEncSetIOCudaStreams;             /**< [out]: Client should access ::nvEncSetIOCudaStreams API through this pointer.           */
     PNVENCGETENCODEPRESETCONFIGEX   nvEncGetEncodePresetConfigEx;      /**< [out]: Client should access ::NvEncGetEncodePresetConfigEx() API through this pointer.  */
     PNVENCGETSEQUENCEPARAMEX        nvEncGetSequenceParamEx;           /**< [out]: Client should access ::NvEncGetSequenceParamEx() API through this pointer.       */
-    void*                           reserved2[277];                    /**< [in]:  Reserved and must be set to NULL                                                 */
+    PNVENCRESTOREENCODERSTATE       nvEncRestoreEncoderState;          /**< [out]: Client should access ::NvEncRestoreEncoderState() API through this pointer.      */
+    PNVENCLOOKAHEADPICTURE          nvEncLookaheadPicture;             /**< [out]: Client should access ::NvEncLookaheadPicture() API through this pointer.         */
+    void*                           reserved2[275];                    /**< [in]:  Reserved and must be set to NULL                                                 */
 } NV_ENCODE_API_FUNCTION_LIST;
 
 /** Macro for constructing the version field of ::_NV_ENCODEAPI_FUNCTION_LIST. */

--- a/third_party/NvCodec/include/nvcuvid.h
+++ b/third_party/NvCodec/include/nvcuvid.h
@@ -1,7 +1,7 @@
 /*
  * This copyright notice applies to this header file only:
  *
- * Copyright (c) 2010-2022 NVIDIA Corporation
+ * Copyright (c) 2010-2023 NVIDIA Corporation
  *
  * Permission is hereby granted, free of charge, to any person
  * obtaining a copy of this software and associated documentation


### PR DESCRIPTION
NVIDIA Video Codec SDK を 12.1 にアップデート
この対応では以下を行なっています。
- `third_party/NvCodec` のアップデート
- ライセンス情報の更新
- `nvcodec_video_encoder.cpp` でコメントアウトしていた箇所を削除

----
This pull request includes updates to the `third_party/NvCodec` to version 12.1, along with associated changes to various files to reflect this update. The most important changes include updating license information, modifying the `nvcodec_video_encoder.cpp` file to remove deprecated parameters, and adding new functionality to the `NvEncoder` class.

### Update to `third_party/NvCodec`:

* [`CHANGES.md`](diffhunk://#diff-d975bf659606195d2165918f93e1cf680ef68ea3c9cab994f033705fea8238b2R14-R20): Updated `third_party/NvCodec` to version 12.1 and made related updates to the README and NOTICE files. Removed deprecated code in `nvcodec_video_encoder.cpp`.

### License updates:

* [`NOTICE.md`](diffhunk://#diff-53337bf7ea91d782c573ac8653c18f95b7b23c38da9de08288639bcec9993406L76-R76): Updated the copyright year to 2023.
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L149-R149): Updated the SDK documentation link to version 12.1.
* Various files in `third_party/NvCodec`: Updated copyright notices and added permission grants. [[1]](diffhunk://#diff-316a2dcd87e5570b86f5c2ab4a9d1c85061fbe20ea6e60c63e0c2d77dd92a807L2-L13) [[2]](diffhunk://#diff-65016437cabf2d1f4d4d1675fb2f4f536a7a4eb7b10067d28cb15863598bfca8L2-R25) [[3]](diffhunk://#diff-b26ff7595cd6b6fac0767cfbfe00a4393ae609a1b1733b4c37a7bf977191c789L2-R25) [[4]](diffhunk://#diff-ca8af23fc38dbfc80b169471aa26238a46f59dbb74f57c8f63fef74f7da11b6aL2-R25) [[5]](diffhunk://#diff-02a92a0412bd328022e665ff127867927cd158acf4eb6fd896a6cab68bfa6f76L2-R25) [[6]](diffhunk://#diff-ef7afd826881f059b8be915678ad877de0629e78733586a828b6f6a110282542L2-R25) [[7]](diffhunk://#diff-8b01d0b3c4e8e2a0b2af69f3c08425d56b06799970a678ce21e410184c30f82fL2-R25) [[8]](diffhunk://#diff-8d2190deac4d7cd865a6b071e548f4d178c8afd88eaaa4f6bc04cac461d278c0L2-R25) [[9]](diffhunk://#diff-d2cfd54a1840d073dab6d483602535255e15c841aedbb4af240050392d502fc6L2-R25) [[10]](diffhunk://#diff-ef4bae58c214ef3ea71bbbf04c131f80d065c906e8c4cb6a3d0944e6075d78f4L2-R25) [[11]](diffhunk://#diff-fd311e73a401ee8336e38c16e4e2573156a3dfe949e4fb93fe61ca0d94699354L4-R4) [[12]](diffhunk://#diff-5cf87b77201e4c83088e2456b000f04ae8c22886f9622b9159473367aa41ef8cL4-R4)

### Code updates:

* [`src/hwenc_nvcodec/nvcodec_video_encoder.cpp`](diffhunk://#diff-fefa72e45345be51780966392a813559a833928744a99ac541c4f03a3c2c1ad9L619): Removed deprecated `NV_ENC_PARAMS_RC_CBR_LOWDELAY_HQ` parameter.
* [`third_party/NvCodec/NvCodec/NvEncoder/NvEncoder.cpp`](diffhunk://#diff-b26ff7595cd6b6fac0767cfbfe00a4393ae609a1b1733b4c37a7bf977191c789R424-R429): Added a check to ensure `frameIntervalP` does not exceed `gopLength`.
* [`third_party/NvCodec/NvCodec/NvEncoder/NvEncoder.h`](diffhunk://#diff-ca8af23fc38dbfc80b169471aa26238a46f59dbb74f57c8f63fef74f7da11b6aR278-R282): Added `GetinitializeParams` method to return encoder initialization parameters.
* [`third_party/NvCodec/Utils/NvCodecUtils.h`](diffhunk://#diff-ef4bae58c214ef3ea71bbbf04c131f80d065c906e8c4cb6a3d0944e6075d78f4L464-R480): Modified `full` method in `ConcurrentQueue` to handle cases where `maxSize` is zero.