### PR TITLE
clang-include-cleaner と clang-format を適用する

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
           key: windows-cuda-${{ steps.versions.outputs.cuda_version }}.v1
       - run: echo "${CUDA_VERSION}" > _install\windows_x86_64\release\cuda.version
         if: steps.cache-cuda.outputs.cache-hit == 'true'
-      - run: python3 run.py --test --run-e2e-test --package ${{ matrix.name }}
+      - run: python3 run.py build --test --run-e2e-test --package ${{ matrix.name }}
         env:
           SORA_CPP_SDK_TEMP_DIR: C:\
       - name: Get package name
@@ -116,7 +116,7 @@ jobs:
         run: |
           echo "user=`users`" >> $GITHUB_OUTPUT
         id: env
-      - run: python3 run.py --test --run-e2e-test --package ${{ matrix.name }}
+      - run: python3 run.py build --test --run-e2e-test --package ${{ matrix.name }}
       - name: Get package name
         run: |
           source _package/${{ matrix.name }}/release/sora.env
@@ -271,7 +271,7 @@ jobs:
       - name: Setup Android SDK
         uses: android-actions/setup-android@v3
         if: matrix.platform.os == 'android'
-      - run: python3 run.py --test --run-e2e-test --package ${{ matrix.platform.name }}
+      - run: python3 run.py build --test --run-e2e-test --package ${{ matrix.platform.name }}
       - name: Get package name
         run: |
           source _package/${{ matrix.platform.name }}/release/sora.env

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -82,9 +82,9 @@ jobs:
           done
         if: matrix.platform.os == 'ubuntu' && matrix.platform.name != 'ubuntu-22.04_armv8'
       - name: Run IWYU
-        run: python3 run.py iwyu ubuntu-24.04_x86_64 || git diff
+        run: python3 run.py iwyu ubuntu-24.04_x86_64 || git diff --exit-code
       - name: Run clang format
-        run: python3 run.py format || git diff
+        run: python3 run.py format || git diff --exit-code
       - name: Check diff
         run: git diff --exit-code
 

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -1,0 +1,112 @@
+name: formatter
+
+on:
+  push:
+    paths-ignore:
+      - "doc/**"
+      - "**.md"
+      - "LICENSE"
+      - "NOTICE"
+
+jobs:
+  run-ubuntu:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - name: ubuntu-24.04_x86_64
+            runs-on: ubuntu-24.04
+            os: ubuntu
+            arch: x86_64
+    name: Build sora-cpp-sdk for ${{ matrix.platform.name }}
+    runs-on: ${{ matrix.platform.runs-on }}
+    env:
+      TEST_SIGNALING_URL: ${{ secrets.TEST_SIGNALING_URL }}
+      TEST_CHANNEL_ID_PREFIX: ${{ secrets.TEST_CHANNEL_ID_PREFIX }}
+      TEST_SECRET_KEY: ${{ secrets.TEST_SECRET_KEY }}
+      TEST_MATRIX_NAME: ${{ matrix.platform.name }}
+    steps:
+      - uses: actions/checkout@v4
+      # IWYU を適用するにはまずビルドする必要がある
+      # Ubuntu 24.04 だと libtinfo5 が見つからない問題があるので、その修正
+      # ref: https://qiita.com/gengen16k/items/88cf3c18a40a94205fab
+      - name: Fix CUDA issues for Ubuntu 24.04
+        if: matrix.platform.name == 'ubuntu-24.04_x86_64'
+        run: |
+          sudo tee /etc/apt/sources.list.d/jammy.list << EOF
+          deb http://archive.ubuntu.com/ubuntu/ jammy universe
+          EOF
+
+          sudo tee /etc/apt/preferences.d/pin-jammy <<EOF
+          Package: *
+          Pin: release n=jammy
+          Pin-Priority: -10
+
+          Package: libtinfo5
+          Pin: release n=jammy
+          Pin-Priority: 990
+          EOF
+      - name: Install deps for ${{ matrix.platform.name }}
+        if: matrix.platform.os == 'ubuntu' && matrix.platform.arch == 'x86_64'
+        run: |
+          source VERSION
+          sudo apt-get update
+          sudo apt-get install -y software-properties-common
+
+          # X11
+          sudo apt-get install libx11-dev libxext-dev
+
+          # OpenGL
+          sudo apt-get install -y libgl-dev
+
+          # CUDA
+          # libssl1.1 が必要
+          wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.0g-2ubuntu4_amd64.deb
+          sudo dpkg -i libssl1.1_1.1.0g-2ubuntu4_amd64.deb
+          wget https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2004/x86_64/cuda-keyring_1.0-1_all.deb
+          sudo dpkg -i cuda-keyring_*all.deb
+          sudo apt-get update
+          DEBIAN_FRONTEND=noninteractive sudo apt-get -y install cuda=$CUDA_VERSION
+
+          # clang-20
+          wget https://apt.llvm.org/llvm.sh
+          chmod a+x llvm.sh
+          sudo ./llvm.sh 20
+      - run: python3 run.py build --test ${{ matrix.platform.name }}
+      - name: Build Examples
+        run: |
+          cd examples
+          mkdir examples_${{ matrix.platform.name }}
+          for app in sdl_sample sumomo messaging_recvonly_sample; do
+            python3 $app/${{ matrix.platform.name }}/run.py --local-sora-cpp-sdk-dir ..
+          done
+        if: matrix.platform.os == 'ubuntu' && matrix.platform.name != 'ubuntu-22.04_armv8'
+      - name: Run IWYU
+        run: python3 run.py iwyu ubuntu-24.04_x86_64
+      - name: Run clang format
+        run: python3 run.py iwyu
+      - name: Check diff
+        run: git diff --exit-code
+
+  notification:
+    name: Slack Notification
+    runs-on: ubuntu-24.04
+    needs:
+      - run-ubuntu
+    if: always()
+    steps:
+      - uses: rtCamp/action-slack-notify@v2
+        if: |
+          needs.build-windows.result == 'failure' ||
+          needs.build-macos.result == 'failure' ||
+          needs.build-ubuntu.result == 'failure' ||
+          needs.create-release.result == 'failure' ||
+          needs.build-windows-examples.result == 'failure' ||
+          needs.build-macos-examples.result == 'failure' ||
+          needs.build-ubuntu-examples.result == 'failure' ||
+          needs.create-release-example.result == 'failure'
+        env:
+          SLACK_CHANNEL: sora-cpp-sdk
+          SLACK_COLOR: danger
+          SLACK_TITLE: Build failed
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -97,14 +97,7 @@ jobs:
     steps:
       - uses: rtCamp/action-slack-notify@v2
         if: |
-          needs.build-windows.result == 'failure' ||
-          needs.build-macos.result == 'failure' ||
-          needs.build-ubuntu.result == 'failure' ||
-          needs.create-release.result == 'failure' ||
-          needs.build-windows-examples.result == 'failure' ||
-          needs.build-macos-examples.result == 'failure' ||
-          needs.build-ubuntu-examples.result == 'failure' ||
-          needs.create-release-example.result == 'failure'
+          needs.run-ubuntu.result == 'failure'
         env:
           SLACK_CHANNEL: sora-cpp-sdk
           SLACK_COLOR: danger

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -82,9 +82,9 @@ jobs:
           done
         if: matrix.platform.os == 'ubuntu' && matrix.platform.name != 'ubuntu-22.04_armv8'
       - name: Run IWYU
-        run: python3 run.py iwyu ubuntu-24.04_x86_64
+        run: python3 run.py iwyu ubuntu-24.04_x86_64 || git diff
       - name: Run clang format
-        run: python3 run.py iwyu
+        run: python3 run.py format || git diff
       - name: Check diff
         run: git diff --exit-code
 

--- a/buildbase.py
+++ b/buildbase.py
@@ -934,7 +934,7 @@ def build_sora(
         ]
 
     with cd(local_sora_cpp_sdk_dir):
-        cmd(["python3", "run.py", platform, *local_sora_cpp_sdk_args])
+        cmd(["python3", "run.py", "build", platform, *local_sora_cpp_sdk_args])
 
 
 class SoraInfo(NamedTuple):

--- a/examples/messaging_recvonly_sample/macos_arm64/run.py
+++ b/examples/messaging_recvonly_sample/macos_arm64/run.py
@@ -142,6 +142,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/messaging_recvonly_sample/src/messaging_recvonly_sample.cpp
+++ b/examples/messaging_recvonly_sample/src/messaging_recvonly_sample.cpp
@@ -1,14 +1,39 @@
+#include <csignal>
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+#include <memory>
 #include <optional>
+#include <ostream>
+#include <string>
+#include <utility>
+#include <vector>
 
-// Sora
-#include <sora/sora_client_context.h>
+// Boost
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/json/parse.hpp>
+#include <boost/json/value.hpp>
+#include <boost/json/value_to.hpp>
+#include <boost/system/detail/error_code.hpp>
 
-// CLI11
-#include <CLI/CLI.hpp>
+// WebRTC
+#include <api/rtp_receiver_interface.h>
+#include <api/rtp_transceiver_interface.h>
+#include <api/scoped_refptr.h>
+#include <rtc_base/logging.h>
 
 #ifdef _WIN32
 #include <rtc_base/win/scoped_com_initializer.h>
 #endif
+
+// CLI11
+#include <CLI/CLI.hpp>
+
+// Sora C++ SDK
+#include <sora/sora_client_context.h>
+#include <sora/sora_signaling.h>
 
 struct MessagingRecvOnlySampleConfig {
   std::string signaling_url;
@@ -92,8 +117,8 @@ class MessagingRecvOnlySample
               << " bytes" << std::endl;
   }
 
-  void OnTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver)
-      override {}
+  void OnTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>
+                   transceiver) override {}
   void OnRemoveTrack(
       webrtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) override {}
 

--- a/examples/messaging_recvonly_sample/ubuntu-22.04_x86_64/run.py
+++ b/examples/messaging_recvonly_sample/ubuntu-22.04_x86_64/run.py
@@ -171,6 +171,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/messaging_recvonly_sample/ubuntu-24.04_armv8/run.py
+++ b/examples/messaging_recvonly_sample/ubuntu-24.04_armv8/run.py
@@ -185,6 +185,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/messaging_recvonly_sample/ubuntu-24.04_x86_64/run.py
+++ b/examples/messaging_recvonly_sample/ubuntu-24.04_x86_64/run.py
@@ -171,6 +171,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/messaging_recvonly_sample/windows_x86_64/run.py
+++ b/examples/messaging_recvonly_sample/windows_x86_64/run.py
@@ -142,6 +142,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/sdl_sample/macos_arm64/run.py
+++ b/examples/sdl_sample/macos_arm64/run.py
@@ -166,6 +166,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/sdl_sample/src/sdl_renderer.cpp
+++ b/examples/sdl_sample/src/sdl_renderer.cpp
@@ -1,13 +1,42 @@
 #include "sdl_renderer.h"
 
+#include <algorithm>
 #include <cmath>
 #include <csignal>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <utility>
 
 // WebRTC
+#include <api/media_stream_interface.h>
+#include <api/scoped_refptr.h>
 #include <api/video/i420_buffer.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_frame_buffer.h>
+#include <api/video/video_rotation.h>
+#include <api/video/video_source_interface.h>
+#include <rtc_base/logging.h>
+#include <rtc_base/synchronization/mutex.h>
+
+// libyuv
 #include <libyuv/convert_from.h>
 #include <libyuv/video_common.h>
-#include <rtc_base/logging.h>
+
+// SDL3
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_events.h>
+#include <SDL3/SDL_init.h>
+#include <SDL3/SDL_keycode.h>
+#include <SDL3/SDL_mouse.h>
+#include <SDL3/SDL_pixels.h>
+#include <SDL3/SDL_rect.h>
+#include <SDL3/SDL_render.h>
+#include <SDL3/SDL_surface.h>
+#include <SDL3/SDL_thread.h>
+#include <SDL3/SDL_timer.h>
+#include <SDL3/SDL_video.h>
 
 #define STD_ASPECT 1.33
 #define WIDE_ASPECT 1.78

--- a/examples/sdl_sample/src/sdl_renderer.h
+++ b/examples/sdl_sample/src/sdl_renderer.h
@@ -1,15 +1,17 @@
 #ifndef SDL_RENDERER_H_
 #define SDL_RENDERER_H_
 
+#include <atomic>
+#include <cstdint>
+#include <functional>
 #include <memory>
-#include <string>
+#include <utility>
 #include <vector>
 
-// SDL
-#include <SDL3/SDL.h>
-
-// Boost
-#include <boost/asio.hpp>
+// SDL3
+#include <SDL3/SDL_render.h>
+#include <SDL3/SDL_thread.h>
+#include <SDL3/SDL_video.h>
 
 // WebRTC
 #include <api/media_stream_interface.h>

--- a/examples/sdl_sample/src/sdl_sample.cpp
+++ b/examples/sdl_sample/src/sdl_sample.cpp
@@ -1,23 +1,45 @@
+#include <csignal>
+#include <cstdlib>
+#include <functional>
+#include <memory>
 #include <optional>
+#include <string>
+#include <utility>
+#include <vector>
 
-// Sora
-#include <sora/camera_device_capturer.h>
-#include <sora/sora_client_context.h>
-
-// CLI11
-#include <CLI/CLI.hpp>
+// Boost
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/json/parse.hpp>
+#include <boost/json/value.hpp>
+#include <boost/system/detail/error_code.hpp>
 
 // WebRTC
+#include <api/audio_options.h>
+#include <api/media_stream_interface.h>
+#include <api/rtc_error.h>
+#include <api/rtp_receiver_interface.h>
+#include <api/rtp_sender_interface.h>
+#include <api/rtp_transceiver_interface.h>
+#include <api/scoped_refptr.h>
 #include <rtc_base/crypto_random.h>
-
-// SDL
-#include <SDL3/SDL_main.h>
-
-#include "sdl_renderer.h"
+#include <rtc_base/logging.h>
 
 #ifdef _WIN32
 #include <rtc_base/win/scoped_com_initializer.h>
 #endif
+
+// CLI11
+#include <CLI/CLI.hpp>
+
+// Sora C++ SDK
+#include <sora/camera_device_capturer.h>
+#include <sora/sora_client_context.h>
+#include <sora/sora_signaling.h>
+
+#include "sdl_renderer.h"
 
 struct SDLSampleConfig {
   std::string signaling_url;

--- a/examples/sdl_sample/ubuntu-22.04_x86_64/run.py
+++ b/examples/sdl_sample/ubuntu-22.04_x86_64/run.py
@@ -188,6 +188,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/sdl_sample/ubuntu-24.04_armv8/run.py
+++ b/examples/sdl_sample/ubuntu-24.04_armv8/run.py
@@ -213,6 +213,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/sdl_sample/ubuntu-24.04_x86_64/run.py
+++ b/examples/sdl_sample/ubuntu-24.04_x86_64/run.py
@@ -188,6 +188,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/sdl_sample/windows_x86_64/run.py
+++ b/examples/sdl_sample/windows_x86_64/run.py
@@ -156,6 +156,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/sumomo/macos_arm64/run.py
+++ b/examples/sumomo/macos_arm64/run.py
@@ -166,6 +166,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/sumomo/src/ansi_renderer.cpp
+++ b/examples/sumomo/src/ansi_renderer.cpp
@@ -1,12 +1,13 @@
 #include "ansi_renderer.h"
 
-#include <iomanip>
+#include <cstdint>
 #include <iostream>
-#include <sstream>
+#include <string>
 #include <vector>
 
+#include "base_renderer.h"
+
 // WebRTC
-#include <rtc_base/logging.h>
 
 AnsiRenderer::AnsiRenderer(int width, int height)
     : BaseRenderer(width, height, 10) {

--- a/examples/sumomo/src/ansi_renderer.h
+++ b/examples/sumomo/src/ansi_renderer.h
@@ -1,6 +1,7 @@
 #ifndef ANSI_RENDERER_H_
 #define ANSI_RENDERER_H_
 
+#include <cstdint>
 #include <string>
 #include <vector>
 

--- a/examples/sumomo/src/base_renderer.cpp
+++ b/examples/sumomo/src/base_renderer.cpp
@@ -3,14 +3,28 @@
 #include <algorithm>
 #include <chrono>
 #include <cmath>
+#include <cstdint>
 #include <cstring>
+#include <memory>
+#include <thread>
+#include <utility>
+#include <vector>
 
 // WebRTC
+#include <api/media_stream_interface.h>
+#include <api/scoped_refptr.h>
 #include <api/video/i420_buffer.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_frame_buffer.h>
+#include <api/video/video_rotation.h>
+#include <api/video/video_source_interface.h>
+#include <rtc_base/logging.h>
+#include <rtc_base/synchronization/mutex.h>
+
+// libyuv
 #include <libyuv/convert_from.h>
 #include <libyuv/planar_functions.h>
 #include <libyuv/video_common.h>
-#include <rtc_base/logging.h>
 
 static constexpr float STD_ASPECT = 1.33f;   // 4:3
 static constexpr float WIDE_ASPECT = 1.78f;  // 16:9

--- a/examples/sumomo/src/base_renderer.h
+++ b/examples/sumomo/src/base_renderer.h
@@ -2,8 +2,10 @@
 #define BASE_RENDERER_H_
 
 #include <atomic>
+#include <cstdint>
 #include <memory>
 #include <thread>
+#include <utility>
 #include <vector>
 
 // WebRTC

--- a/examples/sumomo/src/sdl_renderer.cpp
+++ b/examples/sumomo/src/sdl_renderer.cpp
@@ -1,9 +1,29 @@
 #include "sdl_renderer.h"
 
 #include <csignal>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <utility>
+#include <vector>
+
+// SDL3
+#include <SDL3/SDL_error.h>
+#include <SDL3/SDL_events.h>
+#include <SDL3/SDL_init.h>
+#include <SDL3/SDL_keycode.h>
+#include <SDL3/SDL_mouse.h>
+#include <SDL3/SDL_pixels.h>
+#include <SDL3/SDL_rect.h>
+#include <SDL3/SDL_render.h>
+#include <SDL3/SDL_surface.h>
+#include <SDL3/SDL_video.h>
 
 // WebRTC
 #include <rtc_base/logging.h>
+#include <rtc_base/synchronization/mutex.h>
+
+#include "base_renderer.h"
 
 SDLRenderer::SDLRenderer(int width, int height, bool fullscreen)
     : BaseRenderer(width, height, 30),

--- a/examples/sumomo/src/sdl_renderer.h
+++ b/examples/sumomo/src/sdl_renderer.h
@@ -1,11 +1,13 @@
 #ifndef SDL_RENDERER_H_
 #define SDL_RENDERER_H_
 
+#include <cstdint>
 #include <functional>
 #include <vector>
 
 // SDL
-#include <SDL3/SDL.h>
+#include <SDL3/SDL_render.h>
+#include <SDL3/SDL_video.h>
 
 #include "base_renderer.h"
 

--- a/examples/sumomo/src/sixel_renderer.cpp
+++ b/examples/sumomo/src/sixel_renderer.cpp
@@ -1,10 +1,12 @@
 #include "sixel_renderer.h"
 
-#include <iomanip>
+#include <climits>
+#include <cstdint>
 #include <iostream>
+#include <string>
+#include <vector>
 
-// WebRTC
-#include <rtc_base/logging.h>
+#include "base_renderer.h"
 
 SixelRenderer::SixelRenderer(int width, int height)
     : BaseRenderer(width, height, 10) {

--- a/examples/sumomo/src/sixel_renderer.h
+++ b/examples/sumomo/src/sixel_renderer.h
@@ -1,6 +1,7 @@
 #ifndef SIXEL_RENDERER_H_
 #define SIXEL_RENDERER_H_
 
+#include <cstdint>
 #include <map>
 #include <vector>
 

--- a/examples/sumomo/src/sumomo.cpp
+++ b/examples/sumomo/src/sumomo.cpp
@@ -1,29 +1,61 @@
-// Sora
-#include <sora/camera_device_capturer.h>
-#include <sora/sora_client_context.h>
-#include <sora/sora_video_codec.h>
-
+#include <algorithm>
+#include <csignal>
+#include <cstdlib>
 #include <fstream>
+#include <functional>
+#include <ios>
+#include <iostream>
+#include <iterator>
+#include <memory>
 #include <optional>
+#include <ostream>
 #include <regex>
-#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
 
-// CLI11
-#include <CLI/CLI.hpp>
+// Boost
+#include <boost/asio/dispatch.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/json/parse.hpp>
+#include <boost/json/serialize.hpp>
+#include <boost/json/value.hpp>
+#include <boost/json/value_from.hpp>
+#include <boost/system/detail/error_code.hpp>
 
 // WebRTC
+#include <api/audio_options.h>
+#include <api/media_stream_interface.h>
+#include <api/rtc_error.h>
+#include <api/rtp_parameters.h>
+#include <api/rtp_receiver_interface.h>
+#include <api/rtp_sender_interface.h>
+#include <api/rtp_transceiver_interface.h>
+#include <api/scoped_refptr.h>
+#include <api/video/video_codec_type.h>
 #include <rtc_base/crypto_random.h>
-
-// SDL3
-#include <SDL3/SDL_main.h>
-
-#include "ansi_renderer.h"
-#include "sdl_renderer.h"
-#include "sixel_renderer.h"
+#include <rtc_base/logging.h>
 
 #ifdef _WIN32
 #include <rtc_base/win/scoped_com_initializer.h>
 #endif
+
+// Sora C++ SDK
+#include <sora/amf_context.h>
+#include <sora/camera_device_capturer.h>
+#include <sora/cuda_context.h>
+#include <sora/sora_client_context.h>
+#include <sora/sora_signaling.h>
+#include <sora/sora_video_codec.h>
+
+// CLI11
+#include <CLI/CLI.hpp>
+
+#include "ansi_renderer.h"
+#include "sdl_renderer.h"
+#include "sixel_renderer.h"
 
 struct SumomoConfig {
   std::string signaling_url;

--- a/examples/sumomo/ubuntu-22.04_x86_64/run.py
+++ b/examples/sumomo/ubuntu-22.04_x86_64/run.py
@@ -188,6 +188,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/sumomo/ubuntu-24.04_armv8/run.py
+++ b/examples/sumomo/ubuntu-24.04_armv8/run.py
@@ -213,6 +213,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/sumomo/ubuntu-24.04_x86_64/run.py
+++ b/examples/sumomo/ubuntu-24.04_x86_64/run.py
@@ -188,6 +188,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/examples/sumomo/windows_x86_64/run.py
+++ b/examples/sumomo/windows_x86_64/run.py
@@ -160,6 +160,7 @@ def main():
 
         cmake_args = []
         cmake_args.append(f"-DCMAKE_BUILD_TYPE={configuration}")
+        cmake_args.append("-DCMAKE_EXPORT_COMPILE_COMMANDS=ON")
         cmake_args.append(f"-DBOOST_ROOT={cmake_path(sora_info.boost_install_dir)}")
         cmake_args.append(f"-DWEBRTC_INCLUDE_DIR={cmake_path(webrtc_info.webrtc_include_dir)}")
         cmake_args.append(f"-DWEBRTC_LIBRARY_DIR={cmake_path(webrtc_info.webrtc_library_dir)}")

--- a/include/sora/aligned_encoder_adapter.h
+++ b/include/sora/aligned_encoder_adapter.h
@@ -1,17 +1,16 @@
 #ifndef SORA_ALIGNED_ENCODER_ADAPTER_H_
 #define SORA_ALIGNED_ENCODER_ADAPTER_H_
 
-#include <absl/types/optional.h>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+// WebRTC
 #include <api/fec_controller_override.h>
-#include <api/sequence_checker.h>
-#include <api/video_codecs/sdp_video_format.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_frame_type.h>
+#include <api/video_codecs/video_codec.h>
 #include <api/video_codecs/video_encoder.h>
-#include <api/video_codecs/video_encoder_factory.h>
-#include <common_video/framerate_controller.h>
-#include <modules/video_coding/include/video_codec_interface.h>
-#include <rtc_base/experiments/encoder_info_settings.h>
-#include <rtc_base/system/no_unique_address.h>
-#include <rtc_base/system/rtc_export.h>
 
 namespace sora {
 

--- a/include/sora/audio_device_module.h
+++ b/include/sora/audio_device_module.h
@@ -1,9 +1,11 @@
 #ifndef SORA_AUDIO_DEVICE_MODULE_H_
 #define SORA_AUDIO_DEVICE_MODULE_H_
 
+// WebRTC
+#include <api/audio/audio_device.h>
+#include <api/environment/environment.h>
 #include <api/environment/environment_factory.h>
-#include <api/task_queue/task_queue_factory.h>
-#include <modules/audio_device/include/audio_device.h>
+#include <api/scoped_refptr.h>
 
 namespace sora {
 

--- a/include/sora/audio_output_helper.h
+++ b/include/sora/audio_output_helper.h
@@ -51,7 +51,6 @@
 * 内蔵スピーカーと内蔵マイクの組み合わせを使っていることをもって、ハンズフリーモードであると返すようにしてある。
 */
 
-
 namespace sora {
 
 class AudioChangeRouteObserver {

--- a/include/sora/camera_device_capturer.h
+++ b/include/sora/camera_device_capturer.h
@@ -1,10 +1,14 @@
 #ifndef SORA_CAMERA_DEVICE_CAPTURER_H_
 #define SORA_CAMERA_DEVICE_CAPTURER_H_
 
+#include <functional>
+#include <memory>
 #include <string>
 
 // WebRTC
 #include <api/media_stream_interface.h>
+#include <api/scoped_refptr.h>
+#include <api/video/video_frame.h>
 #include <rtc_base/thread.h>
 
 #include "sora/cuda_context.h"

--- a/include/sora/data_channel.h
+++ b/include/sora/data_channel.h
@@ -1,16 +1,20 @@
 #ifndef SORA_DATA_CHANNEL_H_
 #define SORA_DATA_CHANNEL_H_
 
+#include <cstdint>
 #include <functional>
 #include <map>
 #include <memory>
-#include <set>
+#include <string>
 
 // Boost
-#include <boost/asio.hpp>
+#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/system/detail/error_code.hpp>
 
 // WebRTC
 #include <api/data_channel_interface.h>
+#include <api/scoped_refptr.h>
 
 namespace sora {
 

--- a/include/sora/device_video_capturer.h
+++ b/include/sora/device_video_capturer.h
@@ -10,17 +10,16 @@
 #ifndef SORA_DEVICE_VIDEO_CAPTURER_H_
 #define SORA_DEVICE_VIDEO_CAPTURER_H_
 
-#include <memory>
+#include <cstddef>
 #include <optional>
-#include <vector>
-
-// Boost
-#include <boost/optional.hpp>
+#include <string>
 
 // WebRTC
 #include <api/scoped_refptr.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_sink_interface.h>
 #include <modules/video_capture/video_capture.h>
-#include <rtc_base/ref_counted_object.h>
+#include <modules/video_capture/video_capture_defines.h>
 
 #include "scalable_track_source.h"
 
@@ -41,8 +40,9 @@ struct DeviceVideoCapturerConfig : ScalableVideoTrackSourceConfig {
 // このキャプチャラでは動かない環境もあるため、このキャプチャラを直接利用する必要は無い。
 // 様々な環境で動作するデバイスキャプチャラを利用したい場合、
 // CreateCameraDeviceCapturer 関数を利用して生成するのが良い。
-class DeviceVideoCapturer : public ScalableVideoTrackSource,
-                            public webrtc::VideoSinkInterface<webrtc::VideoFrame> {
+class DeviceVideoCapturer
+    : public ScalableVideoTrackSource,
+      public webrtc::VideoSinkInterface<webrtc::VideoFrame> {
  public:
   static webrtc::scoped_refptr<DeviceVideoCapturer> Create(
       const DeviceVideoCapturerConfig& config);

--- a/include/sora/dyn/dyn.h
+++ b/include/sora/dyn/dyn.h
@@ -1,7 +1,7 @@
 #ifndef DYN_DYN_H_
 #define DYN_DYN_H_
 
-#include <iostream>
+#include <iostream>  // IWYU pragma: export
 #include <map>
 #include <memory>
 #include <string>

--- a/include/sora/dyn/nvcuvid.h
+++ b/include/sora/dyn/nvcuvid.h
@@ -4,6 +4,7 @@
 #include "dyn.h"
 
 // defs
+#include <cuviddec.h>
 #include <nvcuvid.h>
 
 namespace dyn {

--- a/include/sora/hwenc_amf/amf_video_codec.h
+++ b/include/sora/hwenc_amf/amf_video_codec.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 
+#include "sora/amf_context.h"
 #include "sora/sora_video_codec.h"
 
 namespace sora {

--- a/include/sora/hwenc_amf/amf_video_decoder.h
+++ b/include/sora/hwenc_amf/amf_video_decoder.h
@@ -4,6 +4,7 @@
 #include <memory>
 
 // WebRTC
+#include <api/video/video_codec_type.h>
 #include <api/video_codecs/video_decoder.h>
 
 #include "sora/amf_context.h"

--- a/include/sora/hwenc_amf/amf_video_encoder.h
+++ b/include/sora/hwenc_amf/amf_video_encoder.h
@@ -4,8 +4,8 @@
 #include <memory>
 
 // WebRTC
+#include <api/video/video_codec_type.h>
 #include <api/video_codecs/video_encoder.h>
-#include <media/base/codec.h>
 
 #include "sora/amf_context.h"
 

--- a/include/sora/hwenc_nvcodec/nvcodec_decoder_cuda.h
+++ b/include/sora/hwenc_nvcodec/nvcodec_decoder_cuda.h
@@ -1,11 +1,12 @@
 #ifndef SORA_HWENC_NVCODEC_NVCODEC_DECODER_CUDA_H_
 #define SORA_HWENC_NVCODEC_NVCODEC_DECODER_CUDA_H_
 
+#include <cstdint>
 #include <memory>
+#include <string>
 
 // clang-format off
 #include "sora/fix_cuda_noinline_macro_error.h"
-#include <string>
 // clang-format on
 
 #include "sora/cuda_context.h"

--- a/include/sora/hwenc_nvcodec/nvcodec_v4l2_capturer.h
+++ b/include/sora/hwenc_nvcodec/nvcodec_v4l2_capturer.h
@@ -1,7 +1,16 @@
 #ifndef SORA_HWENC_NVCODEC_NVCODEC_V4L2_CAPTURER_H_
 #define SORA_HWENC_NVCODEC_NVCODEC_V4L2_CAPTURER_H_
 
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+
+// WebRTC
+#include <api/scoped_refptr.h>
+#include <modules/video_capture/video_capture.h>
+
 #include "nvcodec_decoder_cuda.h"
+#include "sora/cuda_context.h"
 #include "sora/v4l2/v4l2_video_capturer.h"
 
 namespace sora {

--- a/include/sora/hwenc_nvcodec/nvcodec_video_decoder.h
+++ b/include/sora/hwenc_nvcodec/nvcodec_video_decoder.h
@@ -1,12 +1,13 @@
 #ifndef SORA_HWENC_NVCODEC_NVCODEC_VIDEO_DECODER_H_
 #define SORA_HWENC_NVCODEC_NVCODEC_VIDEO_DECODER_H_
 
-#include <optional>
+#include <cstdint>
+#include <memory>
 
 // WebRTC
+#include <api/video/encoded_image.h>
 #include <api/video_codecs/video_decoder.h>
 #include <common_video/include/video_frame_buffer_pool.h>
-#include <rtc_base/platform_thread.h>
 
 #include "nvcodec_decoder_cuda.h"
 #include "sora/cuda_context.h"

--- a/include/sora/hwenc_nvcodec/nvcodec_video_encoder.h
+++ b/include/sora/hwenc_nvcodec/nvcodec_video_encoder.h
@@ -5,7 +5,6 @@
 
 // WebRTC
 #include <api/video_codecs/video_encoder.h>
-#include <media/base/codec.h>
 
 #include "sora/cuda_context.h"
 

--- a/include/sora/hwenc_vpl/vpl_video_codec.h
+++ b/include/sora/hwenc_vpl/vpl_video_codec.h
@@ -1,6 +1,8 @@
 #ifndef SORA_HWENC_VPL_VPL_VIDEO_CODEC_H_
 #define SORA_HWENC_VPL_VPL_VIDEO_CODEC_H_
 
+#include <memory>
+
 #include "sora/sora_video_codec.h"
 #include "sora/vpl_session.h"
 

--- a/include/sora/hwenc_vpl/vpl_video_decoder.h
+++ b/include/sora/hwenc_vpl/vpl_video_decoder.h
@@ -2,7 +2,6 @@
 #define SORA_HWENC_VPL_VPL_VIDEO_DECODER_H_
 
 #include <memory>
-#include <optional>
 
 // WebRTC
 #include <api/video/video_codec_type.h>

--- a/include/sora/i420_encoder_adapter.h
+++ b/include/sora/i420_encoder_adapter.h
@@ -1,9 +1,15 @@
 #ifndef SORA_I420_ENCODER_ADAPTER_H_
 #define SORA_I420_ENCODER_ADAPTER_H_
 
+#include <cstdint>
 #include <memory>
+#include <vector>
 
 // WebRTC
+#include <api/fec_controller_override.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_frame_type.h>
+#include <api/video_codecs/video_codec.h>
 #include <api/video_codecs/video_encoder.h>
 
 namespace sora {

--- a/include/sora/open_h264_video_codec.h
+++ b/include/sora/open_h264_video_codec.h
@@ -1,7 +1,6 @@
 #ifndef SORA_OPEN_H264_VIDEO_CODEC_H_
 #define SORA_OPEN_H264_VIDEO_CODEC_H_
 
-#include <memory>
 #include <optional>
 #include <string>
 

--- a/include/sora/open_h264_video_decoder.h
+++ b/include/sora/open_h264_video_decoder.h
@@ -5,8 +5,8 @@
 #include <string>
 
 // WebRTC
+#include <api/video_codecs/sdp_video_format.h>
 #include <api/video_codecs/video_decoder.h>
-#include <media/base/codec.h>
 
 namespace sora {
 

--- a/include/sora/open_h264_video_encoder.h
+++ b/include/sora/open_h264_video_encoder.h
@@ -5,8 +5,8 @@
 #include <string>
 
 // WebRTC
+#include <api/video_codecs/sdp_video_format.h>
 #include <api/video_codecs/video_encoder.h>
-#include <media/base/codec.h>
 
 namespace sora {
 

--- a/include/sora/rtc_stats.h
+++ b/include/sora/rtc_stats.h
@@ -1,10 +1,12 @@
 #ifndef SORA_RTC_STATS_H_
 #define SORA_RTC_STATS_H_
 
+#include <functional>
+
 // WebRTC
-#include <api/peer_connection_interface.h>
 #include <api/scoped_refptr.h>
-#include <rtc_base/ref_counted_object.h>
+#include <api/stats/rtc_stats_collector_callback.h>
+#include <api/stats/rtc_stats_report.h>
 
 namespace sora {
 
@@ -18,7 +20,8 @@ class RTCStatsCallback : public webrtc::RTCStatsCollectorCallback {
   static webrtc::scoped_refptr<RTCStatsCallback> Create(
       ResultCallback result_callback);
   void OnStatsDelivered(
-      const webrtc::scoped_refptr<const webrtc::RTCStatsReport>& report) override;
+      const webrtc::scoped_refptr<const webrtc::RTCStatsReport>& report)
+      override;
 
  protected:
   RTCStatsCallback(ResultCallback result_callback);

--- a/include/sora/scalable_track_source.h
+++ b/include/sora/scalable_track_source.h
@@ -11,12 +11,13 @@
 #define SORA_SCALABLE_VIDEO_TRACK_SOURCE_H_
 
 #include <stddef.h>
-
-#include <memory>
+#include <functional>
+#include <optional>
 
 // WebRTC
+#include <api/media_stream_interface.h>
+#include <api/video/video_frame.h>
 #include <media/base/adapted_video_track_source.h>
-#include <media/base/video_adapter.h>
 #include <rtc_base/timestamp_aligner.h>
 
 namespace sora {

--- a/include/sora/session_description.h
+++ b/include/sora/session_description.h
@@ -2,9 +2,13 @@
 #define SORA_SESSION_DESCRIPTION_H_
 
 #include <functional>
+#include <string>
 
 // WebRTC
+#include <api/jsep.h>
 #include <api/peer_connection_interface.h>
+#include <api/rtc_error.h>
+#include <api/scoped_refptr.h>
 
 namespace sora {
 

--- a/include/sora/sora_client_context.h
+++ b/include/sora/sora_client_context.h
@@ -1,12 +1,17 @@
 #ifndef SORA_SORA_CLIENT_CONTEXT_H_
 #define SORA_SORA_CLIENT_CONTEXT_H_
 
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+
 // WebRTC
 #include <api/peer_connection_interface.h>
-#include <media/engine/webrtc_media_engine.h>
+#include <api/scoped_refptr.h>
 #include <pc/connection_context.h>
+#include <rtc_base/thread.h>
 
-#include "sora/sora_signaling.h"
 #include "sora/sora_video_codec_factory.h"
 
 namespace sora {

--- a/include/sora/sora_signaling.h
+++ b/include/sora/sora_signaling.h
@@ -1,22 +1,38 @@
 #ifndef SORA_SORA_SIGNALING_H_INCLUDED
 #define SORA_SORA_SIGNALING_H_INCLUDED
 
+#include <cstddef>
+#include <cstdint>
 #include <functional>
+#include <map>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <vector>
 
 // Boost
-#include <boost/json.hpp>
-#include <boost/optional.hpp>
+#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/beast/websocket/rfc6455.hpp>
+#include <boost/json/value.hpp>
+#include <boost/system/detail/error_code.hpp>
 
 // WebRTC
-#include <api/media_stream_interface.h>
+#include <api/data_channel_interface.h>
+#include <api/jsep.h>
+#include <api/packet_socket_factory.h>
 #include <api/peer_connection_interface.h>
+#include <api/rtc_error.h>
+#include <api/rtp_parameters.h>
+#include <api/rtp_receiver_interface.h>
+#include <api/rtp_transceiver_interface.h>
 #include <api/scoped_refptr.h>
+#include <api/stats/rtc_stats_report.h>
+#include <rtc_base/network.h>
 
 #include "sora/data_channel.h"
+#include "sora/url_parts.h"
 #include "sora/version.h"
 #include "sora/websocket.h"
 
@@ -172,7 +188,8 @@ class SoraSignaling : public std::enable_shared_from_this<SoraSignaling>,
   ~SoraSignaling();
   static std::shared_ptr<SoraSignaling> Create(
       const SoraSignalingConfig& config);
-  webrtc::scoped_refptr<webrtc::PeerConnectionInterface> GetPeerConnection() const;
+  webrtc::scoped_refptr<webrtc::PeerConnectionInterface> GetPeerConnection()
+      const;
   std::string GetVideoMid() const;
   std::string GetAudioMid() const;
 
@@ -251,8 +268,8 @@ class SoraSignaling : public std::enable_shared_from_this<SoraSignaling>,
  private:
   void OnSignalingChange(
       webrtc::PeerConnectionInterface::SignalingState new_state) override {}
-  void OnDataChannel(
-      webrtc::scoped_refptr<webrtc::DataChannelInterface> data_channel) override;
+  void OnDataChannel(webrtc::scoped_refptr<webrtc::DataChannelInterface>
+                         data_channel) override;
   void OnStandardizedIceConnectionChange(
       webrtc::PeerConnectionInterface::IceConnectionState new_state) override;
   void OnConnectionChange(
@@ -265,17 +282,18 @@ class SoraSignaling : public std::enable_shared_from_this<SoraSignaling>,
                            const std::string& url,
                            int error_code,
                            const std::string& error_text) override;
-  void OnTrack(
-      webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver) override;
+  void OnTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>
+                   transceiver) override;
   void OnRemoveTrack(
       webrtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) override;
 
   // DataChannelObserver の実装
  private:
-  void OnStateChange(
-      webrtc::scoped_refptr<webrtc::DataChannelInterface> data_channel) override;
-  void OnMessage(webrtc::scoped_refptr<webrtc::DataChannelInterface> data_channel,
-                 const webrtc::DataBuffer& buffer) override;
+  void OnStateChange(webrtc::scoped_refptr<webrtc::DataChannelInterface>
+                         data_channel) override;
+  void OnMessage(
+      webrtc::scoped_refptr<webrtc::DataChannelInterface> data_channel,
+      const webrtc::DataBuffer& buffer) override;
 
  private:
   SoraSignalingConfig config_;

--- a/include/sora/sora_video_codec.h
+++ b/include/sora/sora_video_codec.h
@@ -1,20 +1,21 @@
 #ifndef SORA_SORA_VIDEO_CODEC_H_
 #define SORA_SORA_VIDEO_CODEC_H_
 
-// WebRTC
-#include <api/video/video_codec_type.h>
-
-// Boost
-#include <boost/json.hpp>
-
+#include <functional>
 #include <memory>
 #include <optional>
 #include <string>
 #include <vector>
 
+// WebRTC
+#include <api/video/video_codec_type.h>
+
+// Boost
+#include <boost/json/conversion.hpp>
+#include <boost/json/value.hpp>
+
 #include "amf_context.h"
 #include "cuda_context.h"
-#include "vpl_session.h"
 
 namespace webrtc {
 

--- a/include/sora/sora_video_codec_factory.h
+++ b/include/sora/sora_video_codec_factory.h
@@ -1,7 +1,14 @@
 #ifndef SORA_SORA_VIDEO_CODEC_FACTORY_H_
 #define SORA_SORA_VIDEO_CODEC_FACTORY_H_
 
+#include <functional>
 #include <memory>
+#include <optional>
+
+// WebRTC
+#include <api/video/video_codec_type.h>
+#include <api/video_codecs/video_decoder.h>
+#include <api/video_codecs/video_encoder.h>
 
 #include "sora/sora_video_codec.h"
 #include "sora/sora_video_decoder_factory.h"

--- a/include/sora/sora_video_decoder_factory.h
+++ b/include/sora/sora_video_decoder_factory.h
@@ -1,12 +1,16 @@
 #ifndef SORA_SORA_VIDEO_DECODER_FACTORY_H_
 #define SORA_SORA_VIDEO_DECODER_FACTORY_H_
 
+#include <functional>
 #include <memory>
+#include <utility>
 #include <vector>
 
 // WebRTC
 #include <api/environment/environment.h>
 #include <api/video/video_codec_type.h>
+#include <api/video_codecs/sdp_video_format.h>
+#include <api/video_codecs/video_decoder.h>
 #include <api/video_codecs/video_decoder_factory.h>
 
 #include "sora/cuda_context.h"

--- a/include/sora/sora_video_encoder_factory.h
+++ b/include/sora/sora_video_encoder_factory.h
@@ -1,10 +1,15 @@
 #ifndef SORA_SORA_VIDEO_ENCODER_FACTORY_H_
 #define SORA_SORA_VIDEO_ENCODER_FACTORY_H_
 
+#include <functional>
 #include <memory>
+#include <optional>
+#include <string>
+#include <utility>
 #include <vector>
 
 // WebRTC
+#include <api/environment/environment.h>
 #include <api/video/video_codec_type.h>
 #include <api/video_codecs/sdp_video_format.h>
 #include <api/video_codecs/video_encoder.h>

--- a/include/sora/ssl_verifier.h
+++ b/include/sora/ssl_verifier.h
@@ -6,6 +6,7 @@
 
 // openssl
 #include <openssl/ssl.h>
+#include <openssl/stack.h>
 
 namespace sora {
 

--- a/include/sora/v4l2/v4l2_video_capturer.h
+++ b/include/sora/v4l2/v4l2_video_capturer.h
@@ -13,14 +13,15 @@
 
 #include <stddef.h>
 #include <stdint.h>
-
-#include <memory>
+#include <string>
 
 // WebRTC
-#include <modules/video_capture/video_capture_defines.h>
-#include <modules/video_capture/video_capture_impl.h>
+#include <api/scoped_refptr.h>
+#include <common_video/libyuv/include/webrtc_libyuv.h>
+#include <modules/video_capture/video_capture.h>
 #include <rtc_base/platform_thread.h>
 #include <rtc_base/synchronization/mutex.h>
+#include <rtc_base/thread_annotations.h>
 
 #include "sora/scalable_track_source.h"
 

--- a/include/sora/websocket.h
+++ b/include/sora/websocket.h
@@ -1,9 +1,12 @@
 #ifndef SORA_WEBSOCKET_H_
 #define SORA_WEBSOCKET_H_
 
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <optional>
+#include <string>
+#include <vector>
 
 // Boost
 #include <boost/asio/deadline_timer.hpp>
@@ -14,8 +17,13 @@
 #include <boost/asio/strand.hpp>
 #include <boost/beast/core/flat_buffer.hpp>
 #include <boost/beast/core/multi_buffer.hpp>
-#include <boost/beast/websocket/ssl.hpp>
+#include <boost/beast/http/empty_body.hpp>
+#include <boost/beast/http/message_fwd.hpp>
+#include <boost/beast/http/parser_fwd.hpp>
+#include <boost/beast/http/string_body_fwd.hpp>
+#include <boost/beast/websocket/rfc6455.hpp>
 #include <boost/beast/websocket/stream.hpp>
+#include <boost/system/detail/error_code.hpp>
 
 #include "url_parts.h"
 #include "version.h"

--- a/include/sora/zlib_helper.h
+++ b/include/sora/zlib_helper.h
@@ -1,9 +1,12 @@
 #ifndef SORA_ZLIB_HELPER_H_
 #define SORA_ZLIB_HELPER_H_
 
+#include <cstddef>
+#include <cstdint>
 #include <string>
 
 // zlib
+#include <chromeconf.h>
 #include <zlib.h>
 
 // この define 名が邪魔してるので undef しておく

--- a/run.py
+++ b/run.py
@@ -1178,9 +1178,6 @@ def _iwyu(
 
 
 def _format(
-    target: str,
-    debug: bool,
-    relwithdebinfo: bool,
     clang_format_path: Optional[str] = None,
 ):
     if clang_format_path is None:
@@ -1233,9 +1230,6 @@ def main():
     ip.add_argument("--clang-include-cleaner-path", type=str, default=None)
     fp = sp.add_parser("format")
     fp.set_defaults(op="format")
-    fp.add_argument("target", choices=AVAILABLE_TARGETS)
-    fp.add_argument("--debug", action="store_true")
-    fp.add_argument("--relwithdebinfo", action="store_true")
     fp.add_argument("--clang-format-path", type=str, default=None)
 
     args = parser.parse_args()
@@ -1266,9 +1260,6 @@ def main():
         )
     elif args.op == "format":
         _format(
-            target=args.target,
-            debug=args.debug,
-            relwithdebinfo=args.relwithdebinfo,
             clang_format_path=args.clang_format_path,
         )
 

--- a/src/aligned_encoder_adapter.cpp
+++ b/src/aligned_encoder_adapter.cpp
@@ -1,6 +1,15 @@
 #include "sora/aligned_encoder_adapter.h"
 
-#include <rtc_base/logging.h>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+// WebRTC
+#include <api/fec_controller_override.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_frame_type.h>
+#include <api/video_codecs/video_codec.h>
+#include <api/video_codecs/video_encoder.h>
 
 namespace sora {
 

--- a/src/amf_context_impl.cpp
+++ b/src/amf_context_impl.cpp
@@ -1,9 +1,4 @@
-#include "amf_context_impl.h"
-
 #include <memory>
-
-// AMF
-#include <public/include/core/Result.h>
 
 #include "sora/amf_context.h"
 
@@ -23,7 +18,8 @@ bool AMFContext::CanCreate() {
 #else
 
 // AMF
-#include "public/common/AMFFactory.h"
+#include <public/common/AMFFactory.h>
+#include <public/include/core/Result.h>
 
 #include "amf_context_impl.h"
 

--- a/src/amf_context_impl.cpp
+++ b/src/amf_context_impl.cpp
@@ -1,3 +1,10 @@
+#include "amf_context_impl.h"
+
+#include <memory>
+
+// AMF
+#include <public/include/core/Result.h>
+
 #include "sora/amf_context.h"
 
 #if !defined(USE_AMF_ENCODER)

--- a/src/amf_context_impl.h
+++ b/src/amf_context_impl.h
@@ -1,8 +1,10 @@
 #ifndef SORA_AMF_CONTEXT_IMPL_H_
 #define SORA_AMF_CONTEXT_IMPL_H_
 
+#include <memory>
+
 // AMF
-#include "public/common/AMFFactory.h"
+#include <public/common/AMFFactory.h>
 
 #include "sora/amf_context.h"
 

--- a/src/android/android_capturer.cpp
+++ b/src/android/android_capturer.cpp
@@ -237,8 +237,8 @@ bool AndroidCapturer::Init(JNIEnv* env,
   std::unique_ptr<webrtc::ScopedJavaGlobalRef<jobject>>
       native_capturer_observer(new webrtc::ScopedJavaGlobalRef<jobject>(
           webrtc::jni::CreateJavaNativeCapturerObserver(
-              env,
-              webrtc::scoped_refptr<webrtc::jni::AndroidVideoTrackSource>(this))));
+              env, webrtc::scoped_refptr<webrtc::jni::AndroidVideoTrackSource>(
+                       this))));
   this->Release();
 
   // 以下の Java コードを JNI 経由で呼んで何とか videoCapturer を作る

--- a/src/audio_device_module.cpp
+++ b/src/audio_device_module.cpp
@@ -1,6 +1,9 @@
 #include "sora/audio_device_module.h"
 
+// WebRTC
+#include <api/audio/audio_device.h>
 #include <api/audio/create_audio_device_module.h>
+#include <api/scoped_refptr.h>
 
 #if defined(SORA_CPP_SDK_WINDOWS)
 #include <modules/audio_device/include/audio_device_factory.h>

--- a/src/audio_output_helper.cpp
+++ b/src/audio_output_helper.cpp
@@ -1,5 +1,7 @@
 #include "sora/audio_output_helper.h"
 
+#include <memory>
+
 // WebRTC
 #include <rtc_base/logging.h>
 

--- a/src/camera_device_capturer.cpp
+++ b/src/camera_device_capturer.cpp
@@ -7,7 +7,9 @@
 #include "sora/mac/mac_capturer.h"
 #elif defined(SORA_CPP_SDK_ANDROID)
 #include "sora/android/android_capturer.h"
-#elif defined(SORA_CPP_SDK_UBUNTU) && defined(USE_NVCODEC_ENCODER)
+#elif (defined(SORA_CPP_SDK_UBUNTU_2004) ||  \
+       defined(SORA_CPP_SDK_UBUNTU_2204)) && \
+    defined(USE_NVCODEC_ENCODER)
 #include "sora/hwenc_nvcodec/nvcodec_v4l2_capturer.h"
 #elif defined(__linux__)
 #include "sora/v4l2/v4l2_video_capturer.h"

--- a/src/camera_device_capturer.cpp
+++ b/src/camera_device_capturer.cpp
@@ -1,5 +1,8 @@
 #include "sora/camera_device_capturer.h"
 
+#include <api/media_stream_interface.h>
+#include <api/scoped_refptr.h>
+
 #if defined(__APPLE__)
 #include "sora/mac/mac_capturer.h"
 #elif defined(SORA_CPP_SDK_ANDROID)

--- a/src/cuda_context_cuda.cpp
+++ b/src/cuda_context_cuda.cpp
@@ -1,6 +1,7 @@
-#include "sora/fix_cuda_noinline_macro_error.h"
+#include <memory>
 
 #include "sora/cuda_context.h"
+#include "sora/fix_cuda_noinline_macro_error.h"
 
 #if !defined(USE_NVCODEC_ENCODER)
 

--- a/src/cuda_context_cuda.cpp
+++ b/src/cuda_context_cuda.cpp
@@ -1,3 +1,9 @@
+#include "cuda_context_cuda.h"
+
+#include <memory>
+
+#include "sora/cuda_context.h"
+
 #if !defined(USE_NVCODEC_ENCODER)
 
 namespace sora {
@@ -16,7 +22,6 @@ bool CudaContext::CanCreate() {
 #include "sora/fix_cuda_noinline_macro_error.h"
 
 #include <exception>
-#include <memory>
 
 // CUDA
 #include <cuda.h>
@@ -25,8 +30,6 @@ bool CudaContext::CanCreate() {
 #include "NvEncoder/../../Utils/Logger.h"
 #include "NvEncoder/../../Utils/NvCodecUtils.h"
 
-#include "cuda_context_cuda.h"
-#include "sora/cuda_context.h"
 #include "sora/dyn/cuda.h"
 #include "sora/dyn/dyn.h"
 

--- a/src/cuda_context_cuda.cpp
+++ b/src/cuda_context_cuda.cpp
@@ -1,5 +1,3 @@
-#include "cuda_context_cuda.h"
-
 #include <memory>
 
 #include "sora/cuda_context.h"
@@ -30,6 +28,7 @@ bool CudaContext::CanCreate() {
 #include "NvEncoder/../../Utils/Logger.h"
 #include "NvEncoder/../../Utils/NvCodecUtils.h"
 
+#include "cuda_context_cuda.h"
 #include "sora/dyn/cuda.h"
 #include "sora/dyn/dyn.h"
 

--- a/src/cuda_context_cuda.cpp
+++ b/src/cuda_context_cuda.cpp
@@ -1,8 +1,3 @@
-#include <memory>
-
-#include "sora/cuda_context.h"
-#include "sora/fix_cuda_noinline_macro_error.h"
-
 #if !defined(USE_NVCODEC_ENCODER)
 
 namespace sora {
@@ -18,12 +13,22 @@ bool CudaContext::CanCreate() {
 
 #else
 
-#include "cuda_context_cuda.h"
+#include "sora/fix_cuda_noinline_macro_error.h"
+
+#include <exception>
+#include <memory>
+
+// CUDA
+#include <cuda.h>
 
 // NvCodec
-#include <NvDecoder/NvDecoder.h>
+#include "NvEncoder/../../Utils/Logger.h"
+#include "NvEncoder/../../Utils/NvCodecUtils.h"
 
+#include "cuda_context_cuda.h"
+#include "sora/cuda_context.h"
 #include "sora/dyn/cuda.h"
+#include "sora/dyn/dyn.h"
 
 // どこかにグローバルな logger の定義が必要
 simplelogger::Logger* logger =

--- a/src/cuda_context_cuda.h
+++ b/src/cuda_context_cuda.h
@@ -1,6 +1,9 @@
 #ifndef SORA_CUDA_CONTEXT_CUDA_H_
 #define SORA_CUDA_CONTEXT_CUDA_H_
 
+#include <memory>
+
+// CUDA
 #include <cuda.h>
 
 #include "sora/cuda_context.h"

--- a/src/data_channel.cpp
+++ b/src/data_channel.cpp
@@ -1,5 +1,25 @@
 #include "sora/data_channel.h"
 
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <utility>
+
+// Boost
+#include <boost/asio/error.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/date_time/posix_time/posix_time_duration.hpp>
+#include <boost/system/detail/errc.hpp>
+#include <boost/system/detail/error_code.hpp>
+#include <boost/system/errc.hpp>
+
+// WebRTC
+#include <api/data_channel_interface.h>
+#include <api/scoped_refptr.h>
+#include <rtc_base/logging.h>
+
 namespace sora {
 
 void DataChannel::Thunk::OnStateChange() {

--- a/src/default_video_formats.cpp
+++ b/src/default_video_formats.cpp
@@ -1,13 +1,15 @@
 #include "default_video_formats.h"
 
+#include <vector>
+
 // WebRTC
+#include <api/rtp_parameters.h>
+#include <api/video/video_codec_type.h>
+#include <api/video_codecs/h264_profile_level_id.h>
 #include <api/video_codecs/sdp_video_format.h>
-#include <api/video_codecs/video_codec.h>
-#include <api/video_codecs/vp9_profile.h>
 #include <media/base/media_constants.h>
 #include <modules/video_coding/codecs/av1/av1_svc_config.h>
 #include <modules/video_coding/codecs/h264/include/h264.h>
-#include <modules/video_coding/codecs/vp8/include/vp8.h>
 #include <modules/video_coding/codecs/vp9/include/vp9.h>
 
 namespace sora {

--- a/src/device_list.cpp
+++ b/src/device_list.cpp
@@ -13,7 +13,11 @@
 #include <modules/video_capture/video_capture_factory.h>
 #include <rtc_base/logging.h>
 
-#ifdef SORA_CPP_SDK_ANDROID
+#if defined(SORA_CPP_SDK_WINDOWS)
+#include <modules/audio_device/include/audio_device_factory.h>
+#endif
+
+#if defined(SORA_CPP_SDK_ANDROID)
 #include <sdk/android/native_api/audio_device_module/audio_device_android.h>
 #include <sdk/android/native_api/jni/jvm.h>
 #endif

--- a/src/device_list.cpp
+++ b/src/device_list.cpp
@@ -1,11 +1,14 @@
 #include "sora/device_list.h"
 
-// webrtc
+#include <functional>
+#include <memory>
+#include <string>
+
+// WebRTC
+#include <api/audio/audio_device.h>
+#include <api/audio/audio_device_defines.h>
 #include <api/audio/create_audio_device_module.h>
 #include <api/environment/environment_factory.h>
-#include <api/task_queue/default_task_queue_factory.h>
-#include <modules/audio_device/include/audio_device.h>
-#include <modules/audio_device/include/audio_device_factory.h>
 #include <modules/video_capture/video_capture.h>
 #include <modules/video_capture/video_capture_factory.h>
 #include <rtc_base/logging.h>

--- a/src/device_video_capturer.cpp
+++ b/src/device_video_capturer.cpp
@@ -11,13 +11,25 @@
 #include "sora/device_video_capturer.h"
 
 #include <stdint.h>
-
+#include <algorithm>
+#include <cctype>
+#include <cstddef>
+#include <exception>
+#include <iterator>
 #include <memory>
+#include <string>
 
 // WebRTC
+#include <api/make_ref_counted.h>
+#include <api/scoped_refptr.h>
+#include <api/video/video_frame.h>
+#include <common_video/libyuv/include/webrtc_libyuv.h>
+#include <modules/video_capture/video_capture.h>
 #include <modules/video_capture/video_capture_factory.h>
 #include <rtc_base/checks.h>
 #include <rtc_base/logging.h>
+
+#include "sora/scalable_track_source.h"
 
 namespace sora {
 

--- a/src/hwenc_amf/amf_video_codec.cpp
+++ b/src/hwenc_amf/amf_video_codec.cpp
@@ -1,12 +1,19 @@
 #include "sora/hwenc_amf/amf_video_codec.h"
 
-#include "sora/hwenc_amf/amf_video_decoder.h"
-#include "sora/hwenc_amf/amf_video_encoder.h"
+#include <memory>
+#include <string>
+
+// WebRTC
+#include <api/video/video_codec_type.h>
 
 // AMF
-#include "public/include/core/Version.h"
+#include <public/include/core/Version.h>
 
 #include "../amf_context_impl.h"
+#include "sora/amf_context.h"
+#include "sora/hwenc_amf/amf_video_decoder.h"
+#include "sora/hwenc_amf/amf_video_encoder.h"
+#include "sora/sora_video_codec.h"
 
 namespace sora {
 

--- a/src/hwenc_amf/amf_video_decoder.cpp
+++ b/src/hwenc_amf/amf_video_decoder.cpp
@@ -1,24 +1,43 @@
 #include "sora/hwenc_amf/amf_video_decoder.h"
 
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
 #include <thread>
 
 // WebRTC
+#include <api/scoped_refptr.h>
+#include <api/video/encoded_image.h>
+#include <api/video/i420_buffer.h>
+#include <api/video/video_codec_type.h>
+#include <api/video/video_frame.h>
 #include <api/video_codecs/video_codec.h>
+#include <api/video_codecs/video_decoder.h>
 #include <common_video/include/video_frame_buffer_pool.h>
 #include <modules/video_coding/include/video_error_codes.h>
-#include <rtc_base/checks.h>
 #include <rtc_base/logging.h>
-#include <rtc_base/time_utils.h>
-#include <third_party/libyuv/include/libyuv/convert.h>
+
+// libyuv
+#include <libyuv/convert.h>
 
 // AMF
-#include "public/common/AMFFactory.h"
-#include "public/common/AMFSTL.h"
-#include "public/common/Thread.h"
-#include "public/common/TraceAdapter.h"
-#include "public/include/components/VideoDecoderUVD.h"
+#include <public/common/AMFFactory.h>
+#include <public/common/AMFSTL.h>
+#include <public/common/Thread.h>
+#include <public/common/TraceAdapter.h>
+#include <public/include/components/Component.h>
+#include <public/include/components/VideoDecoderUVD.h>
+#include <public/include/core/Buffer.h>
+#include <public/include/core/Context.h>
+#include <public/include/core/Data.h>
+#include <public/include/core/Plane.h>
+#include <public/include/core/Result.h>
+#include <public/include/core/Surface.h>
 
 #include "../amf_context_impl.h"
+#include "sora/amf_context.h"
 
 #define RETURN_IF_FAILED(res, message)                  \
   if (res != AMF_OK) {                                  \

--- a/src/hwenc_amf/amf_video_encoder.cpp
+++ b/src/hwenc_amf/amf_video_encoder.cpp
@@ -1,36 +1,59 @@
 #include "sora/hwenc_amf/amf_video_encoder.h"
 
-#include <chrono>
+#include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <mutex>
-#include <queue>
 #include <thread>
+#include <vector>
 
 // WebRTC
-#include <api/video/nv12_buffer.h>
-#include <base/strings/utf_string_conversions.h>
+#include <api/scoped_refptr.h>
+#include <api/video/encoded_image.h>
+#include <api/video/render_resolution.h>
+#include <api/video/video_codec_type.h>
+#include <api/video/video_content_type.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_frame_buffer.h>
+#include <api/video/video_frame_type.h>
+#include <api/video/video_rotation.h>
+#include <api/video/video_timing.h>
+#include <api/video_codecs/scalability_mode.h>
+#include <api/video_codecs/video_codec.h>
+#include <api/video_codecs/video_encoder.h>
 #include <common_video/h264/h264_bitstream_parser.h>
 #include <common_video/h265/h265_bitstream_parser.h>
 #include <common_video/include/bitrate_adjuster.h>
-#include <modules/video_coding/codecs/h264/include/h264.h>
+#include <modules/video_coding/codecs/h264/include/h264_globals.h>
 #include <modules/video_coding/include/video_codec_interface.h>
 #include <modules/video_coding/include/video_error_codes.h>
 #include <modules/video_coding/svc/create_scalability_structure.h>
 #include <modules/video_coding/svc/scalable_video_controller.h>
+#include <rtc_base/checks.h>
 #include <rtc_base/logging.h>
 
 // libyuv
-#include <libyuv.h>
+#include <libyuv/convert.h>
 
 // AMF
-#include "public/common/AMFFactory.h"
-#include "public/common/Thread.h"
-#include "public/common/TraceAdapter.h"
-#include "public/include/components/VideoEncoderAV1.h"
-#include "public/include/components/VideoEncoderHEVC.h"
-#include "public/include/components/VideoEncoderVCE.h"
+#include <public/common/AMFFactory.h>
+#include <public/common/AMFSTL.h>
+#include <public/common/Thread.h>
+#include <public/common/TraceAdapter.h>
+#include <public/include/components/Component.h>
+#include <public/include/components/VideoEncoderAV1.h>
+#include <public/include/components/VideoEncoderHEVC.h>
+#include <public/include/components/VideoEncoderVCE.h>
+#include <public/include/core/Buffer.h>
+#include <public/include/core/Context.h>
+#include <public/include/core/Data.h>
+#include <public/include/core/Plane.h>
+#include <public/include/core/Platform.h>
+#include <public/include/core/Result.h>
+#include <public/include/core/Surface.h>
 
 #include "../amf_context_impl.h"
+#include "sora/amf_context.h"
 
 #define RETURN_IF_FAILED(res, message)                  \
   if (res != AMF_OK) {                                  \

--- a/src/hwenc_nvcodec/nvcodec_decoder_cuda.cpp
+++ b/src/hwenc_nvcodec/nvcodec_decoder_cuda.cpp
@@ -1,9 +1,23 @@
 #include "sora/hwenc_nvcodec/nvcodec_decoder_cuda.h"
 
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <sstream>
+#include <string>
+
+// CUDA
+#include <cuda.h>
+
+// NvCodec
 #include <NvDecoder/NvDecoder.h>
+#include <cuviddec.h>
 
 #include "../cuda_context_cuda.h"
+#include "sora/cuda_context.h"
 #include "sora/dyn/cuda.h"
+#include "sora/dyn/nvcuvid.h"
 
 namespace sora {
 

--- a/src/hwenc_nvcodec/nvcodec_v4l2_capturer.cpp
+++ b/src/hwenc_nvcodec/nvcodec_v4l2_capturer.cpp
@@ -1,12 +1,25 @@
 #include "sora/hwenc_nvcodec/nvcodec_v4l2_capturer.h"
 
-// Linux
-#include <sys/ioctl.h>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
 
 // WebRTC
+#include <api/make_ref_counted.h>
+#include <api/scoped_refptr.h>
 #include <api/video/nv12_buffer.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_frame_buffer.h>
+#include <api/video/video_rotation.h>
+#include <modules/video_capture/video_capture.h>
 #include <modules/video_capture/video_capture_factory.h>
 #include <rtc_base/logging.h>
+#include <rtc_base/time_utils.h>
+
+#include "sora/cuda_context.h"
+#include "sora/hwenc_nvcodec/nvcodec_decoder_cuda.h"
+#include "sora/v4l2/v4l2_video_capturer.h"
 
 namespace sora {
 

--- a/src/hwenc_nvcodec/nvcodec_video_codec.cpp
+++ b/src/hwenc_nvcodec/nvcodec_video_codec.cpp
@@ -1,12 +1,16 @@
 #include "sora/hwenc_nvcodec/nvcodec_video_codec.h"
 
-#include <iostream>
+#include <memory>
+#include <string>
 
+// WebRTC
+#include <api/video/video_codec_type.h>
+
+#include "nvcodec_video_codec_cuda.h"
+#include "sora/cuda_context.h"
 #include "sora/hwenc_nvcodec/nvcodec_video_decoder.h"
 #include "sora/hwenc_nvcodec/nvcodec_video_encoder.h"
-
-#include "../cuda_context_cuda.h"
-#include "nvcodec_video_codec_cuda.h"
+#include "sora/sora_video_codec.h"
 
 #if defined(_WIN32)
 #include <d3d11.h>

--- a/src/hwenc_nvcodec/nvcodec_video_codec_cuda.cpp
+++ b/src/hwenc_nvcodec/nvcodec_video_codec_cuda.cpp
@@ -1,6 +1,13 @@
 #include "nvcodec_video_codec_cuda.h"
 
+#include <cstddef>
+#include <memory>
+
+// CUDA
+#include <cuda.h>
+
 #include "../cuda_context_cuda.h"
+#include "sora/cuda_context.h"
 #include "sora/dyn/cuda.h"
 
 namespace sora {

--- a/src/hwenc_nvcodec/nvcodec_video_codec_cuda.h
+++ b/src/hwenc_nvcodec/nvcodec_video_codec_cuda.h
@@ -1,6 +1,9 @@
 #ifndef SORA_HWENC_NVCODEC_NVCODEC_VIDEO_CODEC_CUDA_H_
 #define SORA_HWENC_NVCODEC_NVCODEC_VIDEO_CODEC_CUDA_H_
 
+#include <cstddef>
+#include <memory>
+
 #include "sora/cuda_context.h"
 
 namespace sora {

--- a/src/hwenc_nvcodec/nvcodec_video_decoder.cpp
+++ b/src/hwenc_nvcodec/nvcodec_video_decoder.cpp
@@ -1,17 +1,29 @@
 #include "sora/hwenc_nvcodec/nvcodec_video_decoder.h"
 
+#include <cstdint>
+#include <memory>
+#include <optional>
+
 // WebRTC
+#include <api/scoped_refptr.h>
+#include <api/video/encoded_image.h>
+#include <api/video/i420_buffer.h>
+#include <api/video/video_frame.h>
+#include <api/video_codecs/video_decoder.h>
 #include <modules/video_coding/include/video_error_codes.h>
-#include <rtc_base/checks.h>
 #include <rtc_base/logging.h>
-#include <rtc_base/time_utils.h>
-#include <third_party/libyuv/include/libyuv/convert.h>
+
+// libyuv
+#include <libyuv/convert.h>
 
 // NvCodec
 #include <NvDecoder/NvDecoder.h>
 
+#include "sora/cuda_context.h"
 #include "sora/dyn/cuda.h"
+#include "sora/dyn/dyn.h"
 #include "sora/dyn/nvcuvid.h"
+#include "sora/hwenc_nvcodec/nvcodec_decoder_cuda.h"
 
 namespace sora {
 

--- a/src/hwenc_nvcodec/nvcodec_video_encoder.cpp
+++ b/src/hwenc_nvcodec/nvcodec_video_encoder.cpp
@@ -2,36 +2,52 @@
 
 #include "sora/hwenc_nvcodec/nvcodec_video_encoder.h"
 
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <mutex>
+#include <vector>
+
 #ifdef _WIN32
 #include <d3d11.h>
 #include <wrl.h>
 #endif
 
-#include <chrono>
-#include <memory>
-#include <mutex>
-#include <queue>
-
 // WebRTC
+#include <api/scoped_refptr.h>
+#include <api/video/encoded_image.h>
 #include <api/video/nv12_buffer.h>
+#include <api/video/render_resolution.h>
+#include <api/video/video_codec_type.h>
+#include <api/video/video_content_type.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_frame_buffer.h>
+#include <api/video/video_frame_type.h>
+#include <api/video/video_timing.h>
+#include <api/video_codecs/scalability_mode.h>
+#include <api/video_codecs/video_codec.h>
+#include <api/video_codecs/video_encoder.h>
 #include <common_video/h264/h264_bitstream_parser.h>
 #include <common_video/h265/h265_bitstream_parser.h>
 #include <common_video/include/bitrate_adjuster.h>
-#include <modules/video_coding/codecs/h264/include/h264.h>
+#include <modules/video_coding/codecs/h264/include/h264_globals.h>
 #include <modules/video_coding/include/video_codec_interface.h>
 #include <modules/video_coding/include/video_error_codes.h>
 #include <modules/video_coding/svc/create_scalability_structure.h>
-// create_scalability_structure.h で include 済みだが、依存性を明示するために include する
 #include <modules/video_coding/svc/scalable_video_controller.h>
+#include <rtc_base/checks.h>
 #include <rtc_base/logging.h>
-
-// libyuv
-#include <libyuv.h>
 
 // NvCodec
 #ifdef _WIN32
 #include <NvEncoder/NvEncoderD3D11.h>
 #endif
+
+#include "NvEncoder/NvEncoder.h"
+#include "nvEncodeAPI.h"
+#include "sora/cuda_context.h"
+#include "sora/dyn/dyn.h"
+
 #ifdef __linux__
 #include "nvcodec_video_encoder_cuda.h"
 #endif

--- a/src/hwenc_nvcodec/nvcodec_video_encoder.cpp
+++ b/src/hwenc_nvcodec/nvcodec_video_encoder.cpp
@@ -38,13 +38,18 @@
 #include <rtc_base/checks.h>
 #include <rtc_base/logging.h>
 
+// libyuv
+#include <libyuv/convert_from.h>      // IWYU pragma: keep
+#include <libyuv/planar_functions.h>  // IWYU pragma: keep
+
 // NvCodec
+#include <NvEncoder/NvEncoder.h>
+#include <nvEncodeAPI.h>
+
 #ifdef _WIN32
 #include <NvEncoder/NvEncoderD3D11.h>
 #endif
 
-#include "NvEncoder/NvEncoder.h"
-#include "nvEncodeAPI.h"
 #include "sora/cuda_context.h"
 #include "sora/dyn/dyn.h"
 

--- a/src/hwenc_nvcodec/nvcodec_video_encoder_cuda.cpp
+++ b/src/hwenc_nvcodec/nvcodec_video_encoder_cuda.cpp
@@ -2,13 +2,22 @@
 
 #include "nvcodec_video_encoder_cuda.h"
 
+#include <cstddef>
+#include <cstdlib>
 #include <iostream>
+#include <memory>
+
+// CUDA
+#include <cuda.h>
 
 // NvCodec
-#include <NvDecoder/NvDecoder.h>
+#include <NvEncoder/../../Utils/NvCodecUtils.h>
+#include <NvEncoder/NvEncoder.h>
 #include <NvEncoder/NvEncoderCuda.h>
+#include <nvEncodeAPI.h>
 
 #include "../cuda_context_cuda.h"
+#include "sora/cuda_context.h"
 #include "sora/dyn/cuda.h"
 
 namespace sora {

--- a/src/hwenc_nvcodec/nvcodec_video_encoder_cuda.h
+++ b/src/hwenc_nvcodec/nvcodec_video_encoder_cuda.h
@@ -4,6 +4,9 @@
 // CUDA と WebRTC のヘッダを混ぜてコンパイルすると大量のエラーが発生したので、
 // CUDA の処理だけさせる単純な CUDA ファイルを用意する
 
+#include <memory>
+
+// NvCodec
 #include <NvEncoder/NvEncoder.h>
 
 #include "sora/cuda_context.h"

--- a/src/hwenc_vpl/vpl_utils.h
+++ b/src/hwenc_vpl/vpl_utils.h
@@ -1,11 +1,15 @@
 #ifndef SORA_HWENC_VPL_VPL_UTILS_H_
 #define SORA_HWENC_VPL_VPL_UTILS_H_
 
+#include <string>
+
 // WebRTC
 #include <api/video/video_codec_type.h>
 
 // Intel VPL
 #include <vpl/mfxdefs.h>
+#include <vpl/mfxstructures.h>
+#include <vpl/mfxvp8.h>
 
 #define VPL_CHECK_RESULT(P, X, ERR)                    \
   {                                                    \

--- a/src/hwenc_vpl/vpl_video_codec.cpp
+++ b/src/hwenc_vpl/vpl_video_codec.cpp
@@ -1,9 +1,20 @@
 #include "sora/hwenc_vpl/vpl_video_codec.h"
+#include <memory>
+#include <string>
 
-#include "sora/hwenc_vpl/vpl_video_decoder.h"
-#include "sora/hwenc_vpl/vpl_video_encoder.h"
+// WebRTC
+#include <api/video/video_codec_type.h>
+
+// VPL
+#include <vpl/mfxcommon.h>
+#include <vpl/mfxdefs.h>
+#include <vpl/mfxsession.h>
 
 #include "../vpl_session_impl.h"
+#include "sora/hwenc_vpl/vpl_video_decoder.h"
+#include "sora/hwenc_vpl/vpl_video_encoder.h"
+#include "sora/sora_video_codec.h"
+#include "sora/vpl_session.h"
 
 namespace sora {
 

--- a/src/hwenc_vpl/vpl_video_decoder.cpp
+++ b/src/hwenc_vpl/vpl_video_decoder.cpp
@@ -1,25 +1,38 @@
 #include "sora/hwenc_vpl/vpl_video_decoder.h"
 
-#include <iostream>
-#include <queue>
+#include <algorithm>
+#include <chrono>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <optional>
 #include <thread>
+#include <utility>
+#include <vector>
 
 // WebRTC
+#include <api/scoped_refptr.h>
+#include <api/video/encoded_image.h>
+#include <api/video/i420_buffer.h>
+#include <api/video/video_codec_type.h>
+#include <api/video/video_frame.h>
 #include <api/video_codecs/video_decoder.h>
 #include <common_video/include/video_frame_buffer_pool.h>
 #include <modules/video_coding/include/video_error_codes.h>
-#include <rtc_base/checks.h>
 #include <rtc_base/logging.h>
-#include <rtc_base/platform_thread.h>
-#include <rtc_base/time_utils.h>
-#include <third_party/libyuv/include/libyuv/convert.h>
+
+// libyuv
+#include <libyuv/convert.h>
 
 // Intel VPL
+#include <vpl/mfxcommon.h>
 #include <vpl/mfxdefs.h>
+#include <vpl/mfxstructures.h>
 #include <vpl/mfxvideo++.h>
-#include <vpl/mfxvp8.h>
+#include <vpl/mfxvideo.h>
 
 #include "../vpl_session_impl.h"
+#include "sora/vpl_session.h"
 #include "vpl_utils.h"
 
 namespace sora {

--- a/src/hwenc_vpl/vpl_video_encoder.cpp
+++ b/src/hwenc_vpl/vpl_video_encoder.cpp
@@ -1,26 +1,47 @@
 #include "sora/hwenc_vpl/vpl_video_encoder.h"
 
+#include <algorithm>
 #include <chrono>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <memory>
 #include <mutex>
+#include <vector>
 
 // WebRTC
+#include <api/scoped_refptr.h>
+#include <api/video/encoded_image.h>
+#include <api/video/video_codec_type.h>
+#include <api/video/video_content_type.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_frame_buffer.h>
+#include <api/video/video_frame_type.h>
+#include <api/video/video_timing.h>
+#include <api/video_codecs/video_codec.h>
+#include <api/video_codecs/video_encoder.h>
 #include <common_video/h264/h264_bitstream_parser.h>
 #include <common_video/h265/h265_bitstream_parser.h>
 #include <common_video/include/bitrate_adjuster.h>
-#include <modules/video_coding/codecs/h264/include/h264.h>
+#include <modules/video_coding/codecs/h264/include/h264_globals.h>
 #include <modules/video_coding/include/video_codec_interface.h>
 #include <modules/video_coding/include/video_error_codes.h>
+#include <rtc_base/checks.h>
 #include <rtc_base/logging.h>
-#include <rtc_base/synchronization/mutex.h>
-
-// Intel VPL
-#include <vpl/mfxvideo++.h>
-#include <vpl/mfxvp8.h>
 
 // libyuv
-#include <libyuv.h>
+#include <libyuv/convert_from.h>
+
+// Intel VPL
+#include <vpl/mfxcommon.h>
+#include <vpl/mfxdefs.h>
+#include <vpl/mfxstructures.h>
+#include <vpl/mfxvideo++.h>
+#include <vpl/mfxvideo.h>
+#include <vpl/mfxvp8.h>
 
 #include "../vpl_session_impl.h"
+#include "sora/vpl_session.h"
 #include "vpl_utils.h"
 
 namespace sora {

--- a/src/i420_encoder_adapter.cpp
+++ b/src/i420_encoder_adapter.cpp
@@ -1,6 +1,15 @@
 #include "sora/i420_encoder_adapter.h"
 
-#include <rtc_base/logging.h>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include <api/fec_controller_override.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_frame_buffer.h>
+#include <api/video/video_frame_type.h>
+#include <api/video_codecs/video_codec.h>
+#include <api/video_codecs/video_encoder.h>
 
 namespace sora {
 

--- a/src/mac/mac_capturer.mm
+++ b/src/mac/mac_capturer.mm
@@ -28,7 +28,8 @@
 
 - (void)capturer:(RTCVideoCapturer*)capturer
     didCaptureVideoFrame:(RTCVideoFrame*)frame {
-  const int64_t timestamp_us = frame.timeStampNs / webrtc::kNumNanosecsPerMicrosec;
+  const int64_t timestamp_us =
+      frame.timeStampNs / webrtc::kNumNanosecsPerMicrosec;
   webrtc::scoped_refptr<webrtc::VideoFrameBuffer> buffer =
       webrtc::make_ref_counted<webrtc::ObjCFrameBuffer>(frame.buffer);
   _capturer->OnFrame(webrtc::VideoFrame::Builder()
@@ -66,19 +67,25 @@ AVCaptureDeviceFormat* SelectClosestFormat(AVCaptureDevice* device,
 
 namespace sora {
 
-MacCapturer::MacCapturer(const MacCapturerConfig& config) : ScalableVideoTrackSource(config) {
-  RTC_LOG(LS_INFO) << "MacCapturer width=" << config.width << ", height=" << config.height
+MacCapturer::MacCapturer(const MacCapturerConfig& config)
+    : ScalableVideoTrackSource(config) {
+  RTC_LOG(LS_INFO) << "MacCapturer width=" << config.width
+                   << ", height=" << config.height
                    << ", target_fps=" << config.target_fps;
 
   adapter_ = [[RTCVideoSourceAdapter alloc] init];
   adapter_.capturer = this;
 
   capturer_ = [[RTCCameraVideoCapturer alloc] initWithDelegate:adapter_];
-  AVCaptureDeviceFormat* format = SelectClosestFormat(config.device, config.width, config.height);
-  [capturer_ startCaptureWithDevice:config.device format:format fps:config.target_fps];
+  AVCaptureDeviceFormat* format =
+      SelectClosestFormat(config.device, config.width, config.height);
+  [capturer_ startCaptureWithDevice:config.device
+                             format:format
+                                fps:config.target_fps];
 }
 
-webrtc::scoped_refptr<MacCapturer> MacCapturer::Create(const MacCapturerConfig& config) {
+webrtc::scoped_refptr<MacCapturer> MacCapturer::Create(
+    const MacCapturerConfig& config) {
   MacCapturerConfig c = config;
   if (c.device == nullptr) {
     AVCaptureDevice* device = FindVideoDevice(c.device_name);
@@ -102,12 +109,14 @@ static NSArray<AVCaptureDevice*>* captureDevices() {
   // return session.devices;
   return [AVCaptureDevice devicesWithMediaType:AVMediaTypeVideo];
 #else
-  AVCaptureDeviceDiscoverySession *session = [AVCaptureDeviceDiscoverySession
-    discoverySessionWithDeviceTypes:@[ AVCaptureDeviceTypeBuiltInWideAngleCamera ]
-                          mediaType:AVMediaTypeVideo
-                           position:AVCaptureDevicePositionUnspecified];
+  AVCaptureDeviceDiscoverySession* session = [AVCaptureDeviceDiscoverySession
+      discoverySessionWithDeviceTypes:@[
+        AVCaptureDeviceTypeBuiltInWideAngleCamera
+      ]
+                            mediaType:AVMediaTypeVideo
+                             position:AVCaptureDevicePositionUnspecified];
   return session.devices;
-# endif
+#endif
 }
 
 bool MacCapturer::EnumVideoDevice(
@@ -168,7 +177,8 @@ AVCaptureDevice* MacCapturer::FindVideoDevice(
   }
 
   if (capture_device_index != SIZE_T_MAX) {
-    AVCaptureDevice* device = [captureDevices() objectAtIndex:capture_device_index];
+    AVCaptureDevice* device =
+        [captureDevices() objectAtIndex:capture_device_index];
     RTC_LOG(LS_INFO) << "selected video device: [" << capture_device_index
                      << "] device_name=" << [device.localizedName UTF8String];
     return device;
@@ -184,7 +194,8 @@ void MacCapturer::Stop() {
   [capturer_ stopCaptureWithCompletionHandler:^{
     // self を参照することで、stopCaptureWithCompletionHandler が完了するまで
     // オブジェクトが破棄されないようにする
-    RTC_LOG(LS_INFO) << "MacCapturer::Destroy() completed: self=" << (void*)self.get();
+    RTC_LOG(LS_INFO) << "MacCapturer::Destroy() completed: self="
+                     << (void*)self.get();
   }];
 }
 
@@ -196,4 +207,4 @@ void MacCapturer::OnFrame(const webrtc::VideoFrame& frame) {
   OnCapturedFrame(frame);
 }
 
-}
+}  // namespace sora

--- a/src/mac/mac_version.mm
+++ b/src/mac/mac_version.mm
@@ -92,4 +92,4 @@ std::string MacVersion::GetOSVersion() {
   return [str UTF8String];
 }
 
-}
+}  // namespace sora

--- a/src/mac/mac_video_factory.mm
+++ b/src/mac/mac_video_factory.mm
@@ -30,4 +30,4 @@ std::unique_ptr<webrtc::VideoDecoderFactory> CreateMacVideoDecoderFactory() {
       [[RTCDefaultVideoDecoderFactory alloc] init]);
 }
 
-}
+}  // namespace sora

--- a/src/open_h264_video_codec.cpp
+++ b/src/open_h264_video_codec.cpp
@@ -1,5 +1,8 @@
 #include "sora/open_h264_video_codec.h"
 
+#include <optional>
+#include <string>
+
 #if defined(_WIN32)
 // Windows
 #include <windows.h>
@@ -8,11 +11,13 @@
 #include <dlfcn.h>
 #endif
 
+// WebRTC
+#include <api/video/video_codec_type.h>
+
 // OpenH264
-#include <wels/codec_api.h>
 #include <wels/codec_app_def.h>
-#include <wels/codec_def.h>
-#include <wels/codec_ver.h>
+
+#include "sora/sora_video_codec.h"
 
 namespace sora {
 

--- a/src/open_h264_video_decoder.cpp
+++ b/src/open_h264_video_decoder.cpp
@@ -1,6 +1,11 @@
 #include "sora/open_h264_video_decoder.h"
 
+#include <array>
+#include <cstdint>
 #include <memory>
+#include <optional>
+#include <string>
+#include <utility>
 
 #if defined(_WIN32)
 // Windows
@@ -11,18 +16,24 @@
 #endif
 
 // WebRTC
+#include <api/scoped_refptr.h>
+#include <api/video/encoded_image.h>
 #include <api/video/i420_buffer.h>
+#include <api/video/video_frame.h>
+#include <api/video_codecs/sdp_video_format.h>
+#include <api/video_codecs/video_decoder.h>
 #include <common_video/h264/h264_bitstream_parser.h>
 #include <modules/video_coding/codecs/h264/include/h264.h>
 #include <modules/video_coding/include/video_error_codes.h>
 #include <rtc_base/logging.h>
-#include <third_party/libyuv/include/libyuv.h>
+
+// libyuv
+#include <libyuv/convert.h>
 
 // OpenH264
 #include <wels/codec_api.h>
 #include <wels/codec_app_def.h>
 #include <wels/codec_def.h>
-#include <wels/codec_ver.h>
 
 class ISVCDecoder;
 

--- a/src/open_h264_video_encoder.cpp
+++ b/src/open_h264_video_encoder.cpp
@@ -14,9 +14,14 @@
 
 #include "sora/open_h264_video_encoder.h"
 
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
 #include <limits>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 #if defined(_WIN32)
@@ -29,30 +34,43 @@
 
 // WebRTC
 #include <absl/container/inlined_vector.h>
-#include <absl/strings/match.h>
+#include <absl/memory/memory.h>
 #include <absl/types/optional.h>
+#include <api/environment/environment.h>
 #include <api/environment/environment_factory.h>
-#include <api/transport/rtp/dependency_descriptor.h>
+#include <api/scoped_refptr.h>
+#include <api/units/data_rate.h>
+#include <api/video/encoded_image.h>
 #include <api/video/i420_buffer.h>
+#include <api/video/video_bitrate_allocation.h>
+#include <api/video/video_bitrate_allocator.h>
 #include <api/video/video_codec_constants.h>
+#include <api/video/video_codec_type.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_frame_buffer.h>
+#include <api/video/video_frame_type.h>
 #include <api/video_codecs/scalability_mode.h>
+#include <api/video_codecs/sdp_video_format.h>
+#include <api/video_codecs/video_codec.h>
 #include <api/video_codecs/video_encoder.h>
 #include <common_video/h264/h264_bitstream_parser.h>
 #include <common_video/libyuv/include/webrtc_libyuv.h>
+#include <media/base/media_constants.h>
 #include <modules/video_coding/codecs/h264/include/h264.h>
+#include <modules/video_coding/codecs/h264/include/h264_globals.h>
+#include <modules/video_coding/codecs/interface/common_constants.h>
 #include <modules/video_coding/include/video_codec_interface.h>
 #include <modules/video_coding/include/video_error_codes.h>
 #include <modules/video_coding/svc/create_scalability_structure.h>
 #include <modules/video_coding/svc/scalable_video_controller.h>
-#include <modules/video_coding/utility/quality_scaler.h>
 #include <modules/video_coding/utility/simulcast_rate_allocator.h>
 #include <modules/video_coding/utility/simulcast_utility.h>
 #include <rtc_base/checks.h>
 #include <rtc_base/logging.h>
-#include <rtc_base/time_utils.h>
 #include <system_wrappers/include/metrics.h>
-#include <third_party/libyuv/include/libyuv/convert.h>
-#include <third_party/libyuv/include/libyuv/scale.h>
+
+// libyuv
+#include <libyuv/scale.h>
 
 // OpenH264
 #include <wels/codec_api.h>

--- a/src/rtc_ssl_verifier.cpp
+++ b/src/rtc_ssl_verifier.cpp
@@ -1,7 +1,16 @@
 #include "sora/rtc_ssl_verifier.h"
 
+#include <optional>
+#include <string>
+
 // WebRTC
 #include <rtc_base/boringssl_certificate.h>
+#include <rtc_base/ssl_certificate.h>
+
+// OpenSSL
+#include <openssl/base.h>
+#include <openssl/ssl.h>
+#include <openssl/stack.h>
 
 #include "sora/ssl_verifier.h"
 
@@ -16,7 +25,8 @@ bool RTCSSLVerifier::Verify(const webrtc::SSLCertificate& certificate) {
   if (insecure_) {
     return true;
   }
-  SSL* ssl = static_cast<const webrtc::BoringSSLCertificate&>(certificate).ssl();
+  SSL* ssl =
+      static_cast<const webrtc::BoringSSLCertificate&>(certificate).ssl();
   X509* x509 = SSL_get_peer_certificate(ssl);
   STACK_OF(X509)* chain = SSL_get_peer_cert_chain(ssl);
   return SSLVerifier::VerifyX509(x509, chain, ca_cert_);

--- a/src/rtc_stats.cpp
+++ b/src/rtc_stats.cpp
@@ -1,5 +1,12 @@
 #include "sora/rtc_stats.h"
 
+#include <utility>
+
+// WebRTC
+#include <api/make_ref_counted.h>
+#include <api/scoped_refptr.h>
+#include <api/stats/rtc_stats_report.h>
+
 namespace sora {
 
 webrtc::scoped_refptr<RTCStatsCallback> RTCStatsCallback::Create(

--- a/src/scalable_track_source.cpp
+++ b/src/scalable_track_source.cpp
@@ -10,17 +10,21 @@
 
 #include "sora/scalable_track_source.h"
 
-#include <algorithm>
+#include <cstdint>
+#include <optional>
 
 // WebRTC
+#include <api/media_stream_interface.h>
 #include <api/scoped_refptr.h>
 #include <api/video/i420_buffer.h>
+#include <api/video/video_frame.h>
 #include <api/video/video_frame_buffer.h>
 #include <api/video/video_rotation.h>
-#include <rtc_base/logging.h>
+#include <media/base/adapted_video_track_source.h>
+#include <rtc_base/time_utils.h>
 
 // libyuv
-#include <libyuv.h>
+#include <libyuv/rotate.h>
 
 namespace sora {
 

--- a/src/session_description.cpp
+++ b/src/session_description.cpp
@@ -1,5 +1,17 @@
 #include "sora/session_description.h"
 
+#include <memory>
+#include <string>
+#include <utility>
+
+// WebRTC
+#include <api/jsep.h>
+#include <api/make_ref_counted.h>
+#include <api/peer_connection_interface.h>
+#include <api/rtc_error.h>
+#include <api/scoped_refptr.h>
+#include <rtc_base/logging.h>
+
 namespace sora {
 
 webrtc::scoped_refptr<CreateSessionDescriptionThunk>

--- a/src/sora_client_context.cpp
+++ b/src/sora_client_context.cpp
@@ -1,32 +1,32 @@
 #include "sora/sora_client_context.h"
 
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+#include <vector>
+
 // WebRTC
+#include <absl/memory/memory.h>
+#include <api/audio/audio_device.h>
+#include <api/audio/audio_device_defines.h>
 #include <api/audio/builtin_audio_processing_builder.h>
 #include <api/audio_codecs/builtin_audio_decoder_factory.h>
 #include <api/audio_codecs/builtin_audio_encoder_factory.h>
-#include <api/create_peerconnection_factory.h>
 #include <api/enable_media.h>
 #include <api/environment/environment_factory.h>
+#include <api/peer_connection_interface.h>
 #include <api/rtc_event_log/rtc_event_log_factory.h>
-#include <api/task_queue/default_task_queue_factory.h>
-#include <call/call_config.h>
-#include <media/engine/webrtc_media_engine.h>
-#include <modules/audio_device/include/audio_device.h>
-#include <modules/audio_device/include/audio_device_factory.h>
-#include <modules/audio_processing/include/audio_processing.h>
-#include <modules/video_capture/video_capture.h>
-#include <modules/video_capture/video_capture_factory.h>
 #include <pc/media_factory.h>
-#include <pc/video_track_source_proxy.h>
 #include <rtc_base/logging.h>
 #include <rtc_base/ssl_adapter.h>
+#include <rtc_base/ssl_stream_adapter.h>
+#include <rtc_base/thread.h>
 
 #include "sora/audio_device_module.h"
-#include "sora/camera_device_capturer.h"
 #include "sora/java_context.h"
 #include "sora/sora_peer_connection_factory.h"
-#include "sora/sora_video_decoder_factory.h"
-#include "sora/sora_video_encoder_factory.h"
+#include "sora/sora_video_codec_factory.h"
 
 namespace sora {
 

--- a/src/sora_peer_connection_factory.cpp
+++ b/src/sora_peer_connection_factory.cpp
@@ -1,7 +1,13 @@
 #include "sora/sora_peer_connection_factory.h"
 
+#include <utility>
+
 // WebRTC
 #include <api/environment/environment_factory.h>
+#include <api/make_ref_counted.h>
+#include <api/peer_connection_interface.h>
+#include <api/scoped_refptr.h>
+#include <pc/connection_context.h>
 #include <pc/peer_connection_factory.h>
 #include <pc/peer_connection_factory_proxy.h>
 

--- a/src/sora_signaling.cpp
+++ b/src/sora_signaling.cpp
@@ -1,12 +1,54 @@
 #include "sora/sora_signaling.h"
 
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <exception>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <random>
+#include <string>
+#include <utility>
+#include <vector>
+
+// Boost
+#include <boost/asio/error.hpp>
+#include <boost/asio/post.hpp>
+#include <boost/beast/websocket/error.hpp>
+#include <boost/beast/websocket/rfc6455.hpp>
+#include <boost/core/ignore_unused.hpp>
+#include <boost/date_time/posix_time/posix_time_duration.hpp>
+#include <boost/json/array.hpp>
+#include <boost/json/object.hpp>
+#include <boost/json/parse.hpp>
+#include <boost/json/serialize.hpp>
+#include <boost/json/value.hpp>
+#include <boost/system/detail/errc.hpp>
+#include <boost/system/detail/error_code.hpp>
+#include <boost/system/errc.hpp>
+
 // WebRTC
+#include <api/data_channel_interface.h>
 #include <api/environment/environment_factory.h>
+#include <api/jsep.h>
+#include <api/media_types.h>
+#include <api/peer_connection_interface.h>
+#include <api/rtc_error.h>
+#include <api/rtp_parameters.h>
+#include <api/rtp_receiver_interface.h>
+#include <api/rtp_sender_interface.h>
+#include <api/rtp_transceiver_interface.h>
+#include <api/scoped_refptr.h>
+#include <api/stats/rtc_stats_report.h>
 #include <p2p/client/basic_port_allocator.h>
 #include <pc/rtp_media_utils.h>
-#include <pc/session_description.h>
+#include <rtc_base/copy_on_write_buffer.h>
 #include <rtc_base/crypt_string_revive.h>
+#include <rtc_base/logging.h>
 #include <rtc_base/proxy_info_revive.h>
+#include <rtc_base/socket_address.h>
+#include <rtc_base/ssl_certificate.h>
 
 #include "sora/data_channel.h"
 #include "sora/rtc_ssl_verifier.h"
@@ -14,6 +56,7 @@
 #include "sora/session_description.h"
 #include "sora/url_parts.h"
 #include "sora/version.h"
+#include "sora/websocket.h"
 #include "sora/zlib_helper.h"
 
 namespace sora {

--- a/src/sora_video_codec.cpp
+++ b/src/sora_video_codec.cpp
@@ -21,6 +21,7 @@
 #include <api/video_codecs/video_codec.h>
 #include <rtc_base/logging.h>
 
+#include "sora/java_context.h"  // IWYU pragma: keep
 #include "sora/open_h264_video_codec.h"
 #include "sora/vpl_session.h"
 

--- a/src/sora_video_codec.cpp
+++ b/src/sora_video_codec.cpp
@@ -1,12 +1,28 @@
 #include "sora/sora_video_codec.h"
 
+#include <algorithm>
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+// Boost
+#include <boost/json/conversion.hpp>
+#include <boost/json/serialize.hpp>
+#include <boost/json/value.hpp>
+#include <boost/json/value_from.hpp>
+#include <boost/json/value_to.hpp>
+
 // WebRTC
+#include <api/video/video_codec_type.h>
 #include <api/video_codecs/builtin_video_decoder_factory.h>
 #include <api/video_codecs/builtin_video_encoder_factory.h>
+#include <api/video_codecs/sdp_video_format.h>
+#include <api/video_codecs/video_codec.h>
 #include <rtc_base/logging.h>
 
-#include "sora/java_context.h"
 #include "sora/open_h264_video_codec.h"
+#include "sora/vpl_session.h"
 
 #if defined(SORA_CPP_SDK_IOS) || defined(SORA_CPP_SDK_MACOS)
 #include "sora/mac/mac_video_factory.h"

--- a/src/sora_video_codec_factory.cpp
+++ b/src/sora_video_codec_factory.cpp
@@ -1,15 +1,30 @@
 #include "sora/sora_video_codec_factory.h"
 
+#include <algorithm>
+#include <cassert>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Boost
+#include <boost/json/serialize.hpp>
+#include <boost/json/value_from.hpp>
+
 // WebRTC
 #include <api/video_codecs/builtin_video_decoder_factory.h>
 #include <api/video_codecs/builtin_video_encoder_factory.h>
 #include <api/video_codecs/sdp_video_format.h>
 #include <api/video_codecs/video_codec.h>
+#include <api/video_codecs/video_decoder_factory.h>
+#include <api/video_codecs/video_encoder_factory.h>
 #include <rtc_base/logging.h>
 
+#include "sora/sora_video_decoder_factory.h"
+#include "sora/sora_video_encoder_factory.h"
+#include "sora/vpl_session.h"
+
 #if !defined(__arm__) || defined(__aarch64__) || defined(__ARM_NEON__)
-#include <modules/video_coding/codecs/av1/dav1d_decoder.h>
-#include <modules/video_coding/codecs/av1/libaom_av1_encoder.h>
 #endif
 
 #if defined(__APPLE__)
@@ -35,9 +50,6 @@
 #include "sora/hwenc_amf/amf_video_encoder.h"
 #endif
 
-#include "default_video_formats.h"
-#include "sora/aligned_encoder_adapter.h"
-#include "sora/i420_encoder_adapter.h"
 #include "sora/open_h264_video_decoder.h"
 #include "sora/open_h264_video_encoder.h"
 #include "sora/sora_video_codec.h"

--- a/src/sora_video_codec_factory.cpp
+++ b/src/sora_video_codec_factory.cpp
@@ -12,6 +12,7 @@
 #include <boost/json/value_from.hpp>
 
 // WebRTC
+#include <api/video/video_codec_type.h>  // IWYU pragma: keep
 #include <api/video_codecs/builtin_video_decoder_factory.h>
 #include <api/video_codecs/builtin_video_encoder_factory.h>
 #include <api/video_codecs/sdp_video_format.h>
@@ -20,6 +21,7 @@
 #include <api/video_codecs/video_encoder_factory.h>
 #include <rtc_base/logging.h>
 
+#include "sora/cuda_context.h"  // IWYU pragma: keep
 #include "sora/sora_video_decoder_factory.h"
 #include "sora/sora_video_encoder_factory.h"
 #include "sora/vpl_session.h"

--- a/src/sora_video_decoder_factory.cpp
+++ b/src/sora_video_decoder_factory.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 
 // WebRTC
+#include <absl/memory/memory.h>  // IWYU pragma: keep
 #include <api/environment/environment.h>
 #include <api/environment/environment_factory.h>
 #include <api/video/video_codec_type.h>

--- a/src/sora_video_decoder_factory.cpp
+++ b/src/sora_video_decoder_factory.cpp
@@ -1,16 +1,19 @@
 #include "sora/sora_video_decoder_factory.h"
 
+#include <functional>
+#include <memory>
+#include <utility>
+#include <vector>
+
 // WebRTC
-#include <absl/strings/match.h>
+#include <api/environment/environment.h>
 #include <api/environment/environment_factory.h>
+#include <api/video/video_codec_type.h>
 #include <api/video_codecs/sdp_video_format.h>
-#include <media/base/codec.h>
-#include <media/base/media_constants.h>
-#include <modules/video_coding/codecs/h264/include/h264.h>
+#include <api/video_codecs/video_codec.h>
+#include <api/video_codecs/video_decoder.h>
 #include <modules/video_coding/codecs/vp8/include/vp8.h>
 #include <modules/video_coding/codecs/vp9/include/vp9.h>
-#include <rtc_base/checks.h>
-#include <rtc_base/logging.h>
 
 #if !defined(__arm__) || defined(__aarch64__) || defined(__ARM_NEON__)
 #include <modules/video_coding/codecs/av1/dav1d_decoder.h>
@@ -33,6 +36,8 @@
 #endif
 
 #include "default_video_formats.h"
+#include "sora/cuda_context.h"
+#include "sora/vpl_session.h"
 
 namespace sora {
 

--- a/src/sora_video_encoder_factory.cpp
+++ b/src/sora_video_encoder_factory.cpp
@@ -1,19 +1,22 @@
 #include "sora/sora_video_encoder_factory.h"
 
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
 // WebRTC
-#include <absl/memory/memory.h>
-#include <absl/strings/match.h>
+#include <api/environment/environment.h>
 #include <api/environment/environment_factory.h>
+#include <api/video/video_codec_type.h>
 #include <api/video_codecs/sdp_video_format.h>
 #include <api/video_codecs/video_codec.h>
-#include <api/video_codecs/vp9_profile.h>
-#include <media/base/codec.h>
-#include <media/base/media_constants.h>
+#include <api/video_codecs/video_encoder.h>
 #include <media/engine/simulcast_encoder_adapter.h>
-#include <modules/video_coding/codecs/h264/include/h264.h>
 #include <modules/video_coding/codecs/vp8/include/vp8.h>
 #include <modules/video_coding/codecs/vp9/include/vp9.h>
-#include <rtc_base/logging.h>
 
 #if !defined(__arm__) || defined(__aarch64__) || defined(__ARM_NEON__)
 #include <modules/video_coding/codecs/av1/libaom_av1_encoder.h>
@@ -37,8 +40,10 @@
 
 #include "default_video_formats.h"
 #include "sora/aligned_encoder_adapter.h"
+#include "sora/cuda_context.h"
 #include "sora/i420_encoder_adapter.h"
 #include "sora/open_h264_video_encoder.h"
+#include "sora/vpl_session.h"
 
 namespace sora {
 

--- a/src/ssl_verifier.cpp
+++ b/src/ssl_verifier.cpp
@@ -1,17 +1,22 @@
 #include "sora/ssl_verifier.h"
 
-// webrtc
+#include <cstddef>
+#include <functional>
+#include <optional>
+#include <string>
+#include <utility>
+
+// WebRTC
 #include <rtc_base/logging.h>
-#include <rtc_base/openssl_utility.h>
 #include <rtc_base/ssl_roots.h>
 
-// openssl
-#include <openssl/x509v3.h>
-
-// boost
-#include <boost/asio/connect.hpp>
-#include <boost/asio/io_context.hpp>
-#include <boost/asio/ip/tcp.hpp>
+// OpenSSL
+#include <openssl/base.h>
+#include <openssl/bio.h>
+#include <openssl/err.h>
+#include <openssl/pem.h>
+#include <openssl/stack.h>
+#include <openssl/x509.h>
 
 namespace sora {
 

--- a/src/url_parts.cpp
+++ b/src/url_parts.cpp
@@ -1,5 +1,8 @@
 #include "sora/url_parts.h"
 
+#include <string>
+#include <utility>
+
 namespace sora {
 
 bool URLParts::Parse(std::string url, URLParts& parts) {

--- a/src/v4l2/v4l2_video_capturer.cpp
+++ b/src/v4l2/v4l2_video_capturer.cpp
@@ -10,13 +10,12 @@
 
 #include "sora/v4l2/v4l2_video_capturer.h"
 
-// C
 #include <stdio.h>
 #include <string.h>
 #include <time.h>
-
-// C++
-#include <new>
+#include <cstdint>
+#include <functional>
+#include <memory>
 #include <string>
 
 // Linux
@@ -29,14 +28,27 @@
 #include <unistd.h>
 
 // WebRTC
+#include <api/make_ref_counted.h>
 #include <api/scoped_refptr.h>
 #include <api/video/i420_buffer.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_frame_buffer.h>
+#include <api/video/video_rotation.h>
+#include <bits/types/struct_timeval.h>
+#include <common_video/libyuv/include/webrtc_libyuv.h>
 #include <media/base/video_common.h>
 #include <modules/video_capture/video_capture.h>
 #include <modules/video_capture/video_capture_factory.h>
 #include <rtc_base/logging.h>
-#include <rtc_base/ref_counted_object.h>
-#include <third_party/libyuv/include/libyuv.h>
+#include <rtc_base/platform_thread.h>
+#include <rtc_base/synchronization/mutex.h>
+#include <rtc_base/time_utils.h>
+
+// libyuv
+#include <libyuv/convert.h>
+#include <libyuv/rotate.h>
+
+#include "sora/scalable_track_source.h"
 
 #define MJPEG_EOS_SEARCH_SIZE 4096
 

--- a/src/version.cpp
+++ b/src/version.cpp
@@ -5,7 +5,8 @@
 #include <string>
 #include <vector>
 
-// boost
+// Boost
+#include <boost/algorithm/string/classification.hpp>
 #include <boost/algorithm/string/split.hpp>
 #include <boost/algorithm/string/trim.hpp>
 

--- a/src/vpl_session_impl.cpp
+++ b/src/vpl_session_impl.cpp
@@ -1,3 +1,7 @@
+#include "vpl_session_impl.h"
+
+#include <memory>
+
 #include "sora/vpl_session.h"
 
 #if !defined(USE_VPL_ENCODER)
@@ -12,11 +16,14 @@ std::shared_ptr<VplSession> VplSession::Create() {
 
 #else
 
+// WebRTC
 #include <rtc_base/logging.h>
 
-// Intel VPL
+// VPL
+#include <vpl/mfxcommon.h>
+#include <vpl/mfxdefs.h>
 #include <vpl/mfxdispatcher.h>
-#include <vpl/mfxvideo.h>
+#include <vpl/mfxsession.h>
 
 namespace sora {
 

--- a/src/vpl_session_impl.cpp
+++ b/src/vpl_session_impl.cpp
@@ -1,5 +1,3 @@
-#include "vpl_session_impl.h"
-
 #include <memory>
 
 #include "sora/vpl_session.h"
@@ -15,6 +13,8 @@ std::shared_ptr<VplSession> VplSession::Create() {
 }  // namespace sora
 
 #else
+
+#include "vpl_session_impl.h"
 
 // WebRTC
 #include <rtc_base/logging.h>

--- a/src/vpl_session_impl.h
+++ b/src/vpl_session_impl.h
@@ -1,10 +1,9 @@
 #ifndef SORA_VPL_SESSION_IMPL_H_
 #define SORA_VPL_SESSION_IMPL_H_
 
-#include <memory>
 #include <vpl/mfxsession.h>
+#include <memory>
 #if defined(USE_VPL_ENCODER)
-
 
 // Intel VPL
 

--- a/src/vpl_session_impl.h
+++ b/src/vpl_session_impl.h
@@ -1,12 +1,12 @@
 #ifndef SORA_VPL_SESSION_IMPL_H_
 #define SORA_VPL_SESSION_IMPL_H_
 
+#include <memory>
+#include <vpl/mfxsession.h>
 #if defined(USE_VPL_ENCODER)
 
-#include <iostream>
 
 // Intel VPL
-#include <vpl/mfxvideo++.h>
 
 #include "sora/vpl_session.h"
 

--- a/src/websocket.cpp
+++ b/src/websocket.cpp
@@ -1,19 +1,57 @@
 #include "sora/websocket.h"
 
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
 #include <utility>
 
 // WebRTC
-#include <rtc_base/logging.h>
 #include <rtc_base/base64.h>
+#include <rtc_base/logging.h>
 
 // Boost
-#include <boost/asio/bind_executor.hpp>
+#include <boost/asio/buffer.hpp>
 #include <boost/asio/connect.hpp>
+#include <boost/asio/error.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/ip/tcp.hpp>
 #include <boost/asio/post.hpp>
+#include <boost/asio/ssl/context.hpp>
+#include <boost/asio/ssl/context_base.hpp>
+#include <boost/asio/ssl/error.hpp>
+#include <boost/asio/ssl/stream_base.hpp>
+#include <boost/asio/ssl/verify_context.hpp>
+#include <boost/asio/ssl/verify_mode.hpp>
 #include <boost/beast/core/buffers_to_string.hpp>
+#include <boost/beast/core/flat_buffer.hpp>
+#include <boost/beast/http/empty_body.hpp>
+#include <boost/beast/http/field.hpp>
+#include <boost/beast/http/impl/read.hpp>
+#include <boost/beast/http/impl/write.hpp>
+#include <boost/beast/http/message_fwd.hpp>
+#include <boost/beast/http/parser_fwd.hpp>
+#include <boost/beast/http/string_body_fwd.hpp>
+#include <boost/beast/http/verb.hpp>
+#include <boost/beast/websocket/rfc6455.hpp>
+#include <boost/beast/websocket/ssl.hpp>  // IWYU pragma: keep
 #include <boost/beast/websocket/stream.hpp>
+#include <boost/beast/websocket/stream_base.hpp>
+#include <boost/date_time/posix_time/posix_time_duration.hpp>
+#include <boost/system/detail/errc.hpp>
+#include <boost/system/detail/error_code.hpp>
+#include <boost/system/errc.hpp>
+
+// OpenSSL
+#include <openssl/base.h>
+#include <openssl/err.h>
+#include <openssl/ssl.h>
+#include <openssl/stack.h>
+#include <openssl/x509.h>
 
 #include "sora/ssl_verifier.h"
+#include "sora/url_parts.h"
 #include "sora/version.h"
 
 namespace sora {

--- a/src/zlib_helper.cpp
+++ b/src/zlib_helper.cpp
@@ -1,5 +1,14 @@
 #include "sora/zlib_helper.h"
 
+#include <zlib.h>
+#include <cstddef>
+#include <cstdint>
+#include <exception>
+#include <string>
+
+// zlib
+#include <chromeconf.h>
+
 namespace sora {
 
 std::string ZlibHelper::Compress(const std::string& input, int level) {

--- a/test/blend2d_iwyu.h
+++ b/test/blend2d_iwyu.h
@@ -1,0 +1,17 @@
+// Blend2D は <blend2d.h> だけを include するのを期待しているので、
+// IWYU が変に include しないようにするために Blend2D のヘッダを
+// export しておく
+
+// IWYU pragma: begin_exports
+#include <blend2d.h>
+#include <blend2d/api.h>
+#include <blend2d/array.h>
+#include <blend2d/context.h>
+#include <blend2d/font.h>
+#include <blend2d/fontdata.h>
+#include <blend2d/fontface.h>
+#include <blend2d/format.h>
+#include <blend2d/geometry.h>
+#include <blend2d/image.h>
+#include <blend2d/rgba.h>
+// IWYU pragma: end_exports

--- a/test/connect_disconnect.cpp
+++ b/test/connect_disconnect.cpp
@@ -1,8 +1,31 @@
 // 接続と切断を繰り返すテスト
+#include <csignal>
 #include <fstream>
 #include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// Boost
+#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/date_time/posix_time/posix_time_duration.hpp>
+#include <boost/json/parse.hpp>
+#include <boost/json/value.hpp>
+#include <boost/system/detail/error_code.hpp>
 
 // WebRTC
+#include <api/audio_options.h>
+#include <api/media_stream_interface.h>
+#include <api/peer_connection_interface.h>
+#include <api/rtc_error.h>
+#include <api/rtp_receiver_interface.h>
+#include <api/rtp_sender_interface.h>
+#include <api/rtp_transceiver_interface.h>
+#include <api/scoped_refptr.h>
 #include <rtc_base/crypto_random.h>
 #include <rtc_base/logging.h>
 
@@ -10,12 +33,10 @@
 #include <rtc_base/win/scoped_com_initializer.h>
 #endif
 
-#include "sora/audio_device_module.h"
-#include "sora/camera_device_capturer.h"
-#include "sora/java_context.h"
-#include "sora/sora_client_context.h"
-#include "sora/sora_video_decoder_factory.h"
-#include "sora/sora_video_encoder_factory.h"
+// Sora C++ SDK
+#include <sora/camera_device_capturer.h>
+#include <sora/sora_client_context.h>
+#include <sora/sora_signaling.h>
 
 struct SoraClientConfig {
   std::vector<std::string> signaling_urls;
@@ -104,8 +125,8 @@ class SoraClient : public std::enable_shared_from_this<SoraClient>,
   void OnPush(std::string text) override {}
   void OnMessage(std::string label, std::string data) override {}
 
-  void OnTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver)
-      override {}
+  void OnTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>
+                   transceiver) override {}
   void OnRemoveTrack(
       webrtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) override {}
 

--- a/test/datachannel.cpp
+++ b/test/datachannel.cpp
@@ -1,20 +1,38 @@
 // DataChannel の送受信を確認するテスト
+#include <csignal>
+#include <cstdlib>
 #include <fstream>
 #include <iostream>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// Boost
+#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/date_time/posix_time/posix_time_duration.hpp>
+#include <boost/json/parse.hpp>
+#include <boost/json/value.hpp>
+#include <boost/system/detail/error_code.hpp>
 
 // WebRTC
+#include <api/peer_connection_interface.h>
+#include <api/rtp_receiver_interface.h>
+#include <api/rtp_transceiver_interface.h>
+#include <api/scoped_refptr.h>
 #include <rtc_base/logging.h>
 
 #ifdef _WIN32
 #include <rtc_base/win/scoped_com_initializer.h>
 #endif
 
-#include "sora/audio_device_module.h"
-#include "sora/camera_device_capturer.h"
-#include "sora/java_context.h"
-#include "sora/sora_client_context.h"
-#include "sora/sora_video_decoder_factory.h"
-#include "sora/sora_video_encoder_factory.h"
+// Sora C++ SDK
+#include <sora/sora_client_context.h>
+#include <sora/sora_signaling.h>
 
 struct SoraClientConfig {
   std::vector<std::string> signaling_urls;
@@ -103,8 +121,8 @@ class SoraClient : public std::enable_shared_from_this<SoraClient>,
     RTC_LOG(LS_INFO) << "OnSwitched: " << text;
   }
 
-  void OnTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver)
-      override {}
+  void OnTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>
+                   transceiver) override {}
   void OnRemoveTrack(
       webrtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) override {}
 

--- a/test/device_list.cpp
+++ b/test/device_list.cpp
@@ -1,6 +1,7 @@
 // デバイス一覧の取得と、それで得られたデバイスの動作確認
 
 #include <iostream>
+#include <string>
 
 // WebRTC
 #include <rtc_base/logging.h>
@@ -9,9 +10,9 @@
 #include <rtc_base/win/scoped_com_initializer.h>
 #endif
 
-#include "sora/camera_device_capturer.h"
-#include "sora/device_list.h"
-#include "sora/java_context.h"
+// Sora C++ SDK
+#include <sora/camera_device_capturer.h>
+#include <sora/device_list.h>
 
 int main(int argc, char* argv[]) {
 #ifdef _WIN32

--- a/test/e2e.cpp
+++ b/test/e2e.cpp
@@ -1,9 +1,24 @@
-#include <cstdint>
+#include <atomic>
+#include <csignal>
 #include <cstdlib>
-#include <fstream>
-#include <iostream>
+#include <memory>
+#include <string>
+
+// Boost
+#include <boost/asio/deadline_timer.hpp>
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/date_time/posix_time/posix_time_duration.hpp>
+#include <boost/json/object.hpp>
+#include <boost/json/parse.hpp>
+#include <boost/system/detail/error_code.hpp>
 
 // WebRTC
+#include <api/media_stream_interface.h>
+#include <api/rtp_receiver_interface.h>
+#include <api/rtp_transceiver_interface.h>
+#include <api/scoped_refptr.h>
 #include <rtc_base/crypto_random.h>
 #include <rtc_base/logging.h>
 
@@ -14,13 +29,9 @@
 // Catch2
 #include <catch2/catch_test_macros.hpp>
 
-// Sora
-#include <sora/audio_device_module.h>
-#include <sora/camera_device_capturer.h>
-#include <sora/java_context.h>
+// Sora C++ SDK
 #include <sora/sora_client_context.h>
-#include <sora/sora_video_decoder_factory.h>
-#include <sora/sora_video_encoder_factory.h>
+#include <sora/sora_signaling.h>
 
 #include "fake_video_capturer.h"
 
@@ -135,8 +146,8 @@ class SoraClient : public std::enable_shared_from_this<SoraClient>,
   void OnMessage(std::string label, std::string data) override {}
   void OnSwitched(std::string text) override {}
 
-  void OnTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver)
-      override {}
+  void OnTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>
+                   transceiver) override {}
   void OnRemoveTrack(
       webrtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) override {}
 

--- a/test/fake_video_capturer.cpp
+++ b/test/fake_video_capturer.cpp
@@ -1,18 +1,24 @@
 #include "fake_video_capturer.h"
 
+#include <atomic>
 #include <chrono>
+#include <cstdint>
 #include <memory>
+#include <string>
 #include <thread>
 
 // WebRTC
+#include <api/make_ref_counted.h>
+#include <api/scoped_refptr.h>
 #include <api/video/i420_buffer.h>
-#include <rtc_base/ref_counted_object.h>
+#include <api/video/video_frame.h>
+#include <api/video/video_rotation.h>
 
 // libyuv
-#include <libyuv.h>
+#include <libyuv/convert.h>
 
 // Blend2D
-#include <blend2d.h>
+#include "blend2d_iwyu.h"
 
 #include "kosugi_regular_ttf.bin"
 

--- a/test/fake_video_capturer.h
+++ b/test/fake_video_capturer.h
@@ -1,6 +1,9 @@
 #ifndef FAKE_VIDEO_CAPTURER_H_
 #define FAKE_VIDEO_CAPTURER_H_
 
+// WebRTC
+#include <api/scoped_refptr.h>
+
 // Sora C++ SDK
 #include <sora/scalable_track_source.h>
 

--- a/test/hello.cpp
+++ b/test/hello.cpp
@@ -1,9 +1,30 @@
 #include "hello.h"
 
+#include <csignal>
+#include <cstdint>
 #include <fstream>
 #include <iostream>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// Boost
+#include <boost/asio/executor_work_guard.hpp>
+#include <boost/asio/io_context.hpp>
+#include <boost/asio/signal_set.hpp>
+#include <boost/json/parse.hpp>
+#include <boost/json/parse_options.hpp>
+#include <boost/json/value.hpp>
+#include <boost/json/value_to.hpp>
+#include <boost/system/detail/error_code.hpp>
 
 // WebRTC
+#include <api/audio_options.h>
+#include <api/rtc_error.h>
+#include <api/rtp_parameters.h>
+#include <api/rtp_sender_interface.h>
+#include <api/scoped_refptr.h>
 #include <rtc_base/crypto_random.h>
 #include <rtc_base/logging.h>
 
@@ -12,12 +33,12 @@
 #endif
 
 // Sora C++ SDK
-#include <sora/audio_device_module.h>
-#include <sora/camera_device_capturer.h>
+#include <sora/amf_context.h>
+#include <sora/cuda_context.h>
 #include <sora/java_context.h>
+#include <sora/sora_client_context.h>
+#include <sora/sora_signaling.h>
 #include <sora/sora_video_codec.h>
-#include <sora/sora_video_decoder_factory.h>
-#include <sora/sora_video_encoder_factory.h>
 
 #include "fake_video_capturer.h"
 

--- a/test/hello.h
+++ b/test/hello.h
@@ -1,7 +1,25 @@
 #ifndef TEST_HELLO_H_
 #define TEST_HELLO_H_
 
-#include "sora/sora_client_context.h"
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+// Boost
+#include <boost/asio/io_context.hpp>
+
+// WebRTC
+#include <api/media_stream_interface.h>
+#include <api/peer_connection_interface.h>
+#include <api/rtp_parameters.h>
+#include <api/rtp_receiver_interface.h>
+#include <api/rtp_transceiver_interface.h>
+#include <api/scoped_refptr.h>
+
+// Sora C++ SDK
+#include <sora/sora_client_context.h>
+#include <sora/sora_signaling.h>
 
 struct HelloSoraConfig {
   std::vector<std::string> signaling_urls;
@@ -39,8 +57,8 @@ class HelloSora : public std::enable_shared_from_this<HelloSora>,
   void OnPush(std::string text) override {}
   void OnMessage(std::string label, std::string data) override {}
 
-  void OnTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface> transceiver)
-      override {}
+  void OnTrack(webrtc::scoped_refptr<webrtc::RtpTransceiverInterface>
+                   transceiver) override {}
   void OnRemoveTrack(
       webrtc::scoped_refptr<webrtc::RtpReceiverInterface> receiver) override {}
 

--- a/test/ios/hello/AppDelegate.h
+++ b/test/ios/hello/AppDelegate.h
@@ -9,6 +9,4 @@
 
 @interface AppDelegate : UIResponder <UIApplicationDelegate>
 
-
 @end
-

--- a/test/ios/hello/SceneDelegate.h
+++ b/test/ios/hello/SceneDelegate.h
@@ -9,7 +9,6 @@
 
 @interface SceneDelegate : UIResponder <UIWindowSceneDelegate>
 
-@property (strong, nonatomic) UIWindow * window;
+@property(strong, nonatomic) UIWindow* window;
 
 @end
-

--- a/test/ios/hello/ViewController.h
+++ b/test/ios/hello/ViewController.h
@@ -10,4 +10,3 @@
 @interface ViewController : UIViewController
 
 @end
-


### PR DESCRIPTION
`python3 run.py iwyu ubuntu-24.04_x86_64` や `python3 run.py format` で適用できるようにしました。

これを使えるようにする関係で、ビルドするためのコマンドが `python3 run.py ubuntu-24.04_x86_64` から `python3 run.py build ubuntu-24.04_x86_64` になりました。

また、これらを自動的にチェックして、差分があったらエラーにするワークフローも作っています。
