### PR TITLE
[WIP] HEVC (H.265) の SDP に profile/tier/level パラメータを追加

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -101,6 +101,7 @@ target_sources(sora
     src/default_video_formats.cpp
     src/device_list.cpp
     src/device_video_capturer.cpp
+    src/hevc_profile_tier_level.cpp
     src/i420_encoder_adapter.cpp
     src/java_context.cpp
     src/open_h264_video_codec.cpp

--- a/src/default_video_formats.h
+++ b/src/default_video_formats.h
@@ -1,6 +1,7 @@
 #ifndef SORA_DEFAULT_VIDEO_FORMATS_H_
 #define SORA_DEFAULT_VIDEO_FORMATS_H_
 
+#include <optional>
 #include <vector>
 
 // WebRTC
@@ -9,9 +10,18 @@
 
 namespace sora {
 
+// 前方宣言
+enum class HevcHardwareType;
+
 std::vector<webrtc::SdpVideoFormat> GetDefaultVideoFormats(
     webrtc::VideoCodecType codec);
 
-}
+// ハードウェアタイプを指定できるオーバーロード版
+std::vector<webrtc::SdpVideoFormat> GetDefaultVideoFormats(
+    webrtc::VideoCodecType codec,
+    HevcHardwareType hw_type,
+    std::optional<int> max_hevc_level = std::nullopt);
+
+}  // namespace sora
 
 #endif

--- a/src/hevc_profile_tier_level.cpp
+++ b/src/hevc_profile_tier_level.cpp
@@ -1,0 +1,84 @@
+#include "hevc_profile_tier_level.h"
+
+// WebRTC
+#include <media/base/media_constants.h>
+
+namespace sora {
+
+std::vector<webrtc::SdpVideoFormat> GetHevcFormatsForHardware(
+    HevcHardwareType hw_type,
+    std::optional<int> max_level) {
+  std::vector<webrtc::SdpVideoFormat> formats;
+
+  // デフォルトのレベル設定
+  std::vector<int> supported_levels = {93};  // Level 3.1 (必須)
+
+  // ハードウェアタイプごとの設定
+  int profile_id = 1;  // Main Profile
+  int tier_flag = 0;   // Main Tier
+
+  if (hw_type == HevcHardwareType::kIntelVpl) {
+    // Intel VPL は Main Profile のみサポート
+    profile_id = 1;
+    tier_flag = 0;
+    if (max_level.has_value()) {
+      supported_levels.clear();
+      // VPL のレベル値を SDP level-id に変換
+      int sdp_level = ConvertVplLevelToSdpLevelId(max_level.value());
+      // 最高レベルのみを使用（最低でも Level 3.1）
+      supported_levels.push_back(std::max(sdp_level, 93));
+    }
+  } else if (hw_type == HevcHardwareType::kAmdAmf) {
+    // AMD AMF は Main/Main 10 Profile、Main/High Tier をサポート
+    // ここでは Main Profile, Main Tier をデフォルトとする
+    profile_id = 1;
+    tier_flag = 0;
+    if (max_level.has_value()) {
+      supported_levels.clear();
+      int sdp_level = ConvertAmfLevelToSdpLevelId(max_level.value());
+      // 最高レベルのみを使用（最低でも Level 3.1）
+      supported_levels.push_back(std::max(sdp_level, 93));
+    }
+  } else if (hw_type == HevcHardwareType::kAppleVideoToolbox) {
+    // Apple VideoToolbox は Main Profile をサポート
+    profile_id = 1;
+    tier_flag = 0;
+    // macOS Chrome の例に従って Level 3.1 のみ
+    supported_levels = {93};
+  } else if (hw_type == HevcHardwareType::kNvidiaVideo) {
+    // NVIDIA は通常 Main/Main 10 Profile をサポート
+    profile_id = 1;
+    tier_flag = 0;
+  } else {
+    // ハードウェアタイプが不明な場合はデフォルトの Level 3.1 を使用
+    // または空のベクターを返すことも可能
+  }
+
+  // SdpVideoFormat を生成
+  for (int level : supported_levels) {
+    webrtc::CodecParameterMap params = {
+        {"profile-id", std::to_string(profile_id)},
+        {"tier-flag", std::to_string(tier_flag)},
+        {"level-id", std::to_string(level)},
+        {"tx-mode", "SRST"}  // Single RTP stream on a Single media Transport
+    };
+    formats.push_back(webrtc::SdpVideoFormat(webrtc::kH265CodecName, params));
+  }
+
+  // Main 10 Profile もサポートする場合（AMD AMF など）
+  // 注: 通常は1つのプロファイルのみを返すべきだが、
+  // 必要に応じて Main 10 Profile を追加できる
+  // if (hw_type == HevcHardwareType::kAmdAmf && !supported_levels.empty()) {
+  //   webrtc::CodecParameterMap params_main10 = {
+  //       {"profile-id", "2"},  // Main 10 Profile
+  //       {"tier-flag", "0"},   // Main Tier
+  //       {"level-id", std::to_string(supported_levels[0])},
+  //       {"tx-mode", "SRST"}};
+  //   formats.push_back(
+  //       webrtc::SdpVideoFormat(webrtc::kH265CodecName, params_main10));
+  // }
+
+  return formats;
+}
+
+}  // namespace sora

--- a/src/hevc_profile_tier_level.h
+++ b/src/hevc_profile_tier_level.h
@@ -1,0 +1,90 @@
+#ifndef SORA_HEVC_PROFILE_TIER_LEVEL_H_
+#define SORA_HEVC_PROFILE_TIER_LEVEL_H_
+
+#include <optional>
+#include <string>
+#include <vector>
+
+// WebRTC
+#include <api/video_codecs/sdp_video_format.h>
+
+// Intel VPL
+#ifdef SORA_CPP_SDK_USE_INTEL_VPL
+#include <vpl/mfxdefs.h>
+#include <vpl/mfxstructures.h>
+#endif
+
+// AMD AMF
+#ifdef SORA_CPP_SDK_USE_AMD_AMF
+#include <AMF/components/VideoEncoderHEVC.h>
+#endif
+
+namespace sora {
+
+// HEVC プロファイル、ティア、レベルを管理する構造体
+struct HevcProfileTierLevel {
+  int profile_id;  // 1: Main, 2: Main 10
+  int tier_flag;   // 0: Main Tier, 1: High Tier
+  int level_id;    // 93: Level 3.1, 120: Level 4.0, etc.
+};
+
+// Intel VPL のレベル値を SDP level-id に変換
+// VPL: 31 (MFX_LEVEL_HEVC_31) -> SDP: 93
+inline int ConvertVplLevelToSdpLevelId(int vpl_level) {
+  // VPL のレベル値を変換
+  // 31 -> 3.1 -> 93
+  // 40 -> 4.0 -> 120
+  if (vpl_level == 10) {  // MFX_LEVEL_HEVC_1
+    return 30;
+  } else if (vpl_level == 20) {  // MFX_LEVEL_HEVC_2
+    return 60;
+  } else if (vpl_level == 21) {  // MFX_LEVEL_HEVC_21
+    return 63;
+  } else if (vpl_level == 30) {  // MFX_LEVEL_HEVC_3
+    return 90;
+  } else if (vpl_level == 31) {  // MFX_LEVEL_HEVC_31
+    return 93;
+  } else if (vpl_level == 40) {  // MFX_LEVEL_HEVC_4
+    return 120;
+  } else if (vpl_level == 41) {  // MFX_LEVEL_HEVC_41
+    return 123;
+  } else if (vpl_level == 50) {  // MFX_LEVEL_HEVC_5
+    return 150;
+  } else if (vpl_level == 51) {  // MFX_LEVEL_HEVC_51
+    return 153;
+  } else if (vpl_level == 52) {  // MFX_LEVEL_HEVC_52
+    return 156;
+  } else if (vpl_level == 60) {  // MFX_LEVEL_HEVC_6
+    return 180;
+  } else if (vpl_level == 61) {  // MFX_LEVEL_HEVC_61
+    return 183;
+  } else if (vpl_level == 62) {  // MFX_LEVEL_HEVC_62
+    return 186;
+  } else {
+    return 93;  // デフォルトは Level 3.1
+  }
+}
+
+// AMD AMF のレベル値は既に SDP level-id と同じ
+// AMF: 93 (AMF_LEVEL_3_1) -> SDP: 93
+inline int ConvertAmfLevelToSdpLevelId(int amf_level) {
+  return amf_level;  // AMF のレベル値はそのまま使える
+}
+
+// ハードウェアエンコーダーのタイプ
+enum class HevcHardwareType {
+  kIntelVpl,
+  kAmdAmf,
+  kNvidiaVideo,
+  kAppleVideoToolbox,
+  kUnknown  // ハードウェアタイプが不明な場合
+};
+
+// ハードウェアエンコーダーに応じた HEVC フォーマットを生成
+std::vector<webrtc::SdpVideoFormat> GetHevcFormatsForHardware(
+    HevcHardwareType hw_type,
+    std::optional<int> max_level = std::nullopt);
+
+}  // namespace sora
+
+#endif  // SORA_HEVC_PROFILE_TIER_LEVEL_H_


### PR DESCRIPTION
RFC draft-ietf-avtcore-hevc-webrtc-06 に従って、answer 時の SDP に HEVC のプロファイル情報を含めるように実装。

主な変更:
- デフォルトで Main Profile, Main Tier, Level 3.1 を設定
- ハードウェアエンコーダーごとの動的レベル取得に対応
  - Intel VPL と AMD AMF のレベル値を SDP level-id に変換
- tx-mode=SRST (Single RTP stream on Single Transport) を設定

HEVC は必ずハードウェアアクセラレーションを使用するため、
ソフトウェア実装は提供しない。