### PR TITLE
Apple のみビルド対象であるため、formatter.yml はコメントアウトする

### DIFF
--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -2,11 +2,11 @@ name: formatter
 
 on:
   workflow_dispatch:
-  push:
-    paths:
-      - "src/**"
-      - "include/**"
-      - "examples/**"
+  #push:
+  #  paths:
+  #    - "src/**"
+  #    - "include/**"
+  #    - "examples/**"
 
 jobs:
   run-ubuntu:

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -2,7 +2,7 @@ name: formatter
 
 on:
   workflow_dispatch:
-  # formatter は Ubuntu バイナリでの動作を前提としているため、visionOS では自動実行しない
+  # formatter は Ubuntu ランナー上での Ubuntu バイナリ実行を前提としているため、visionOS ブランチでは自動実行しない
   #push:
   #  paths:
   #    - "src/**"

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -2,6 +2,7 @@ name: formatter
 
 on:
   workflow_dispatch:
+  # formatter は Ubuntu バイナリでの動作を前提としているため、visionOS では自動実行しない
   #push:
   #  paths:
   #    - "src/**"

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,7 +29,8 @@
 - [CHANGE] CI を Apple 系のみ実行するようにする
   - GitHub Actions の `build.yml` で、macOS と iOS と visionOS のみ実行するように変更する
   - @torikizi
-- [CHANGE] Apple のみビルド対象であるため、formatter.yml はコメントアウトする
+- [CHANGE] visionOS ブランチでは formatter.yml の push トリガーをコメントアウトする
+  - formatter は Ubuntu ランナー上での Ubuntu バイナリ実行を前提としているため、visionOS ブランチでは自動実行しない
   - @torikizi
 
 ## 2026.1.2

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -29,6 +29,8 @@
 - [CHANGE] CI を Apple 系のみ実行するようにする
   - GitHub Actions の `build.yml` で、macOS と iOS と visionOS のみ実行するように変更する
   - @torikizi
+- [CHANGE] Apple のみビルド対象であるため、formatter.yml はコメントアウトする
+  - @torikizi
 
 ## 2026.1.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -31,6 +31,7 @@
   - @torikizi
 - [CHANGE] visionOS ブランチでは formatter.yml の push トリガーをコメントアウトする
   - formatter は Ubuntu ランナー上での Ubuntu バイナリ実行を前提としているため、visionOS ブランチでは自動実行しない
+  - develop との互換性を維持するため formatter.yml は削除しない
   - @torikizi
 
 ## 2026.1.2


### PR DESCRIPTION
Ubuntu バイナリを使用した formatter の自動実行を無効にする対応をしました