### PR TITLE
Slack 通知を rtCamp/action-slack-notify から shiguredo/github-actions に切り替える

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -505,7 +505,10 @@ jobs:
 
   notification:
     name: Slack Notification
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
+    permissions:
+      actions: read
+      contents: read
     needs:
       - build-windows
       - build-macos
@@ -513,14 +516,15 @@ jobs:
       - e2e-test
     if: always()
     steps:
-      - uses: rtCamp/action-slack-notify@v2
+      - uses: shiguredo/github-actions/.github/actions/slack-notify@main
         if: |
           needs.build-windows.result == 'failure' ||
           needs.build-macos.result == 'failure' ||
           needs.build-ubuntu.result == 'failure' ||
           needs.e2e-test.result == 'failure'
+        with:
+          status: ${{ job.status }}
+          slack_channel: sora-cpp-sdk
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
         env:
-          SLACK_CHANNEL: sora-cpp-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: CI failed
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/formatter.yml
+++ b/.github/workflows/formatter.yml
@@ -112,20 +112,24 @@ jobs:
 
   notification:
     name: Slack Notification
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
+    permissions:
+      actions: read
+      contents: read
     needs:
       - run-ubuntu
     if: always()
     steps:
-      - uses: rtCamp/action-slack-notify@v2
+      - uses: shiguredo/github-actions/.github/actions/slack-notify@main
         if: |
           needs.run-ubuntu.result == 'failure'
-        env:
-          SLACK_CHANNEL: sora-cpp-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: フォーマット失敗
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          SLACK_MESSAGE: |
+        with:
+          status: ${{ job.status }}
+          slack_channel: sora-cpp-sdk
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
+          slack_message: |
             ```
             ${{ needs.run-ubuntu.outputs.diff }}
             ```
+        env:
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -711,7 +711,10 @@ jobs:
 
   notification:
     name: Slack Notification
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-slim
+    permissions:
+      actions: read
+      contents: read
     needs:
       - build-windows
       - build-macos
@@ -724,7 +727,7 @@ jobs:
       - create-release-example
     if: always()
     steps:
-      - uses: rtCamp/action-slack-notify@v2
+      - uses: shiguredo/github-actions/.github/actions/slack-notify@main
         if: |
           needs.build-windows.result == 'failure' ||
           needs.build-macos.result == 'failure' ||
@@ -735,8 +738,9 @@ jobs:
           needs.build-macos-examples.result == 'failure' ||
           needs.build-ubuntu-examples.result == 'failure' ||
           needs.create-release-example.result == 'failure'
+        with:
+          status: ${{ job.status }}
+          slack_channel: sora-cpp-sdk
+          slack_webhook: ${{ secrets.SLACK_WEBHOOK }}
         env:
-          SLACK_CHANNEL: sora-cpp-sdk
-          SLACK_COLOR: danger
-          SLACK_TITLE: Release failed
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          GH_TOKEN: ${{ github.token }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,6 +16,10 @@
 
 ### misc
 
+- [CHANGE] GitHub Actions の Slack 通知を `github-actions-slack-notify` に置き換える
+  - `rtCamp/action-slack-notify@v2` を `shiguredo/github-actions/.github/actions/slack-notify@main` に置き換える
+  - 通知ジョブの `runs-on` を `ubuntu-slim` に変更する
+  - @miosakuma
 - [UPDATE] Examples の DEPS を更新する
   - WEBRTC_BUILD_VERSION を m146.7680.0.0 にあげる
   - @torikizi

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -16,7 +16,7 @@
 
 ### misc
 
-- [CHANGE] GitHub Actions の Slack 通知を `github-actions-slack-notify` に置き換える
+- [CHANGE] GitHub Actions の Slack 通知を `shiguredo/github-actions` に置き換える
   - `rtCamp/action-slack-notify@v2` を `shiguredo/github-actions/.github/actions/slack-notify@main` に置き換える
   - 通知ジョブの `runs-on` を `ubuntu-slim` に変更する
   - @miosakuma


### PR DESCRIPTION
Github Actions の Slack 通知を shiguredo/github-actions に切り替えました。

SLACK_TITLE、SLACK_COLOR は shiguredo/github-actions のデフォルト値を使うように変更しています。
結果、以下の内容に変更になっています
- SLACK_TITLE : コミットメッセージ
- SLACK_COLOR : 自動判別