### PR TITLE
setup-homebrew のブランチを master から main に修正する

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,7 +413,7 @@ jobs:
       # Homebrew のセットアップ (self-hosted macOS ランナー用)
       - name: Setup Homebrew
         if: ${{ runner.environment == 'self-hosted' && startsWith(matrix.platform.platform-name, 'macos') }}
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       # GitHub CLI のインストール (self-hosted macOS ランナー用)
       - name: Install GitHub CLI

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -402,7 +402,7 @@ jobs:
       # Homebrew のセットアップ (self-hosted macOS ランナー用)
       - name: Setup Homebrew
         if: ${{ runner.environment == 'self-hosted' && startsWith(matrix.platform.platform-name, 'macos') }}
-        uses: Homebrew/actions/setup-homebrew@master
+        uses: Homebrew/actions/setup-homebrew@main
 
       # GitHub CLI のインストール (self-hosted macOS ランナー用)
       - name: Install GitHub CLI

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,11 @@
   - @torikizi
 - [UPDATE] Examples の Boost のバージョンを 1.90.0 に上げる
   - @voluntas
+- [UPDATE] Homebrew/actions/setup-homebrew@master を Homebrew/actions/setup-homebrew@main に変更する
+  - 2026 年 6 月 10 日以降のリリースで `Homebrew/actions/setup-homebrew` の master ブランチは無効化されるため、main ブランチを使用するように変更する
+  - 参考 : Homebrew/actions/setup-homebrew のコミットのリンクでも移行の対応が行われている
+    - https://github.com/Homebrew/actions/commit/675fcd27b59e54d310c5484c8c27c01d03da660c
+  - @torikizi
 
 ## 2026.1.2
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -49,7 +49,7 @@
   - @voluntas
 - [UPDATE] Homebrew/actions/setup-homebrew@master を Homebrew/actions/setup-homebrew@main に変更する
   - 2026 年 6 月 10 日以降のリリースで `Homebrew/actions/setup-homebrew` の master ブランチは無効化されるため、main ブランチを使用するように変更する
-  - 参考 : Homebrew/actions/setup-homebrew のコミットのリンクでも移行の対応が行われている
+  - 参考: Homebrew/actions/setup-homebrew で、main ブランチへの移行を促す警告が表示されるようになったことを示すコミット
     - https://github.com/Homebrew/actions/commit/675fcd27b59e54d310c5484c8c27c01d03da660c
   - @torikizi
 


### PR DESCRIPTION
これまでは `Homebrew/actions/setup-homebrew@master` を使用していましたが、master ブランチの運用は廃止され main に切り替わる予定です。
GitHub Actions の結果にも deprecated のメッセージが出ているため、修正します。