### PR TITLE
Raspberry Pi の E2E テストに pytest-retry による retry を追加する

### DIFF
--- a/e2e-test/pyproject.toml
+++ b/e2e-test/pyproject.toml
@@ -9,6 +9,7 @@ dependencies = []
 dev = [
     "pytest",
     "pytest-repeat",
+    "pytest-retry",
     "pytest-timeout",
     "httpx",
     "python-dotenv",

--- a/e2e-test/test_sumomo_raspberry_pi.py
+++ b/e2e-test/test_sumomo_raspberry_pi.py
@@ -11,11 +11,14 @@ import pytest
 from helper import get_codec, get_outbound_rtp, get_simulcast_outbound_rtp, get_transport
 from sumomo import Sumomo
 
-# Raspberry Pi 環境が有効でない場合はスキップ
-pytestmark = pytest.mark.skipif(
-    not os.environ.get("RASPBERRY_PI"),
-    reason="RASPBERRY_PI not set in environment",
-)
+# Raspberry Pi 環境が有効でない場合はスキップし、フレーキー対策で retry する
+pytestmark = [
+    pytest.mark.skipif(
+        not os.environ.get("RASPBERRY_PI"),
+        reason="RASPBERRY_PI not set in environment",
+    ),
+    pytest.mark.flaky(retries=2, delay=5),
+]
 
 
 def test_connection_stats(sora_settings, free_port):


### PR DESCRIPTION
V4L2 M2M や libcamera を実機で叩くため、ネットワーク・カメラデバイス・タイミング起因のフレーキー失敗を吸収する目的で、`test_sumomo_raspberry_pi.py` 内の全テストに `pytest.mark.flaky(retries=2, delay=5)` を適用する。 合計 3 回まで試行し、再試行間に 5 秒の delay を入れる。