### PR TITLE
コメントの追加と CHANGES の修正

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@
   - macOS ビルドと iOS ビルドの cxxflags に `-DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT` を追加する
     - boost 1.91.0 で asio の `kqueue_reactor` 内部 mutex が `atomic_slim_mutex` (`std::atomic::wait` / `notify_one` を利用) に切り替わったが、 webrtc-build 同梱の libc++ + macOS の組み合わせで kevent から完了通知が届かず async_connect がハングする現象を確認した
     - 旧来の pthread ベース mutex 実装に戻すことで回避する
-    - iOS ビルドでは iOS 14.0 でビルドを行っており、iOS 17.4 以上の条件に合致せず影響はないが、バージョン変更後に問題を回避するため macOS ビルドと同様に修正する
+    - IPHONEOS_DEPLOYMENT_TARGET が iOS 17.4 以上の場合に発生する問題であり 14.0 でビルドしているため影響はないが、今後バージョンを上げた際の問題を回避するため macOS ビルドと同様に修正する
   - @voluntas @torikizi
 - [UPDATE] WSS / TURN-TLS のクライアント証明書設定で証明書チェーンを利用できるようにする
   - `SoraSignalingConfig` の `client_cert` はこれまで単体の証明書が前提になっていたが、証明書チェーンを指定できるようにする

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -28,7 +28,7 @@
   - macOS ビルドと iOS ビルドの cxxflags に `-DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT` を追加する
     - boost 1.91.0 で asio の `kqueue_reactor` 内部 mutex が `atomic_slim_mutex` (`std::atomic::wait` / `notify_one` を利用) に切り替わったが、 webrtc-build 同梱の libc++ + macOS の組み合わせで kevent から完了通知が届かず async_connect がハングする現象を確認した
     - 旧来の pthread ベース mutex 実装に戻すことで回避する
-    - iOS ビルドでは iOS 14.0 でビルドを行っているため条件に合致せず影響はないが、バージョン変更後に問題を回避するため macOS ビルドと同様に修正する
+    - iOS ビルドでは iOS 14.0 でビルドを行っており、iOS 17.4 以上の条件に合致せず影響はないが、バージョン変更後に問題を回避するため macOS ビルドと同様に修正する
   - @voluntas @torikizi
 - [UPDATE] WSS / TURN-TLS のクライアント証明書設定で証明書チェーンを利用できるようにする
   - `SoraSignalingConfig` の `client_cert` はこれまで単体の証明書が前提になっていたが、証明書チェーンを指定できるようにする

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,9 +25,10 @@
 - [UPDATE] cmake のバージョンを 4.3.2 にあげる
   - @torikizi
 - [UPDATE] Boost のバージョンを 1.91.0 に上げる
-  - macOS ビルドの cxxflags に `-DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT` を追加する
+  - macOS ビルドと iOS ビルドの cxxflags に `-DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT` を追加する
     - boost 1.91.0 で asio の `kqueue_reactor` 内部 mutex が `atomic_slim_mutex` (`std::atomic::wait` / `notify_one` を利用) に切り替わったが、 webrtc-build 同梱の libc++ + macOS の組み合わせで kevent から完了通知が届かず async_connect がハングする現象を確認した
     - 旧来の pthread ベース mutex 実装に戻すことで回避する
+    - iOS ビルドでは iOS 14.0 でビルドを行っているため条件に合致せず影響はないが、バージョン変更後に問題を回避するため macOS ビルドと同様に修正する
   - @voluntas @torikizi
 - [UPDATE] WSS / TURN-TLS のクライアント証明書設定で証明書チェーンを利用できるようにする
   - `SoraSignalingConfig` の `client_cert` はこれまで単体の証明書が前提になっていたが、証明書チェーンを指定できるようにする

--- a/run.py
+++ b/run.py
@@ -172,6 +172,15 @@ def get_common_cmake_args(
         cxxflags = [
             "-nostdinc++",
             "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE",
+            # boost 1.91.0 で asio に atomic_slim_mutex が導入され、 kqueue_reactor
+            # の内部 mutex がこの実装に切り替わった。 atomic_slim_mutex は
+            # std::atomic<int>::wait / notify_one (C++20 atomic wait) を利用するが、
+            # webrtc-build 同梱の libc++ ヘッダ + 実行時 libc++ の組み合わせで
+            # macOS の async_connect が kevent から完了通知を受け取れずハングする
+            # 事象を確認したため、 旧来の pthread ベース mutex に戻すために本マクロ
+            # を定義している。 examples/sumomo/run.py 側にも同じ定義が必要 (片方
+            # だけ外すと kqueue_reactor のクラスサイズ・mutex 型が TU 間で食い違って
+            # ABI ミスマッチを起こす)。
             "-DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT",
         ]
         args.append(f"-DCMAKE_CXX_FLAGS={' '.join(cxxflags)}")

--- a/run.py
+++ b/run.py
@@ -176,11 +176,9 @@ def get_common_cmake_args(
             # の内部 mutex がこの実装に切り替わった。 atomic_slim_mutex は
             # std::atomic<int>::wait / notify_one (C++20 atomic wait) を利用するが、
             # webrtc-build 同梱の libc++ ヘッダ + 実行時 libc++ の組み合わせで
-            # macOS の async_connect が kevent から完了通知を受け取れずハングする
+            # iOS の async_connect が kevent から完了通知を受け取れずハングする
             # 事象を確認したため、 旧来の pthread ベース mutex に戻すために本マクロ
-            # を定義している。 examples/sumomo/run.py 側にも同じ定義が必要 (片方
-            # だけ外すと kqueue_reactor のクラスサイズ・mutex 型が TU 間で食い違って
-            # ABI ミスマッチを起こす)。
+            # を定義している。
             "-DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT",
         ]
         args.append(f"-DCMAKE_CXX_FLAGS={' '.join(cxxflags)}")

--- a/run.py
+++ b/run.py
@@ -176,9 +176,8 @@ def get_common_cmake_args(
             # の内部 mutex がこの実装に切り替わった。 atomic_slim_mutex は
             # std::atomic<int>::wait / notify_one (C++20 atomic wait) を利用するが、
             # webrtc-build 同梱の libc++ ヘッダ + 実行時 libc++ の組み合わせで
-            # iOS の async_connect が kevent から完了通知を受け取れずハングする
-            # 事象を確認したため、 旧来の pthread ベース mutex に戻すために本マクロ
-            # を定義している。
+            # iOS 17.4 以上がターゲットの場合 async_connect が kevent から完了通知を受け取れずハングする
+            # 事象を確認したため、 旧来の pthread ベース mutex に戻すために本マクロを定義している。
             "-DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT",
         ]
         args.append(f"-DCMAKE_CXX_FLAGS={' '.join(cxxflags)}")


### PR DESCRIPTION
macOS だけでなく iOS にも `DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT` を追加したため、コメントと CHANGES を更新しました。
CHANGES には 現状 iOS ビルドが 14.0 であるため条件に合致しないことを追記しています。