### PR TITLE
macOS Unity Editor とのシンボル衝突を回避する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -41,9 +41,6 @@
 - [UPDATE] WSS / TURN-TLS のクライアント証明書設定で証明書チェーンを利用できるようにする
   - `SoraSignalingConfig` の `client_cert` はこれまで単体の証明書が前提になっていたが、証明書チェーンを指定できるようにする
   - @zztkm
-- [ADD] TURN-TLS のクライアント証明書設定に対応する
-  - `SoraSignalingConfig` の `client_cert` / `client_key` を TURN-TLS にも適用する
-  - @zztkm
 - [UPDATE] 内部コードのリファクタリングを行う
   - インクルードガードの命名規則を統一する
   - 非標準の `__FUNCTION__` をやめて標準の `__func__` に統一する
@@ -58,10 +55,9 @@
   - @melpon
 - [UPDATE] BitrateAdjuster の２引数コンストラクタが deprecated になったので、代わりに３引数コンストラクタを利用する
   - @melpon
-- [UPDATE] macOS Unity Editor とのシンボル衝突を回避する
+- [UPDATE] BOOST_ASIO_ENABLE_VERSION_NAMESPACE を有効化する
   - Unity Editor 6000.3 がエクスポートする `asio_detail_posix_thread_function` と
-     Boost.Asio の同名の `extern "C"` 関数が衝突し、 Sora インスタンス破棄時に
-    SIGSEGV が発生する問題を修正する
+    Boost.Asio の同名の `extern "C"` 関数が衝突し、 Sora インスタンス破棄時に SIGSEGV が発生する問題を修正する
   - `BOOST_ASIO_ENABLE_VERSION_NAMESPACE` を有効化し、
     `BOOST_ASIO_VERSIONED_NAME` で生成される関数名にバージョン識別子を付加することで
     シンボル名を変えて衝突を回避する
@@ -71,6 +67,9 @@
   - 本問題は macOS で発見したが、 `BOOST_ASIO_ENABLE_VERSION_NAMESPACE` は
     全プラットフォームで有効化する
   - @torikizi
+- [ADD] TURN-TLS のクライアント証明書設定に対応する
+  - `SoraSignalingConfig` の `client_cert` / `client_key` を TURN-TLS にも適用する
+  - @zztkm
 - [FIX] カスタムエンジンが複数ある場合、`GetVideoCodecCapability()` で重複したエンジンが返されるのを修正
   - @melpon
 - [FIX] `#if USE_VPL_ENCODER` と `#if defined(USE_VPL_ENCODER)` の不一致を修正する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,6 +58,19 @@
   - @melpon
 - [UPDATE] BitrateAdjuster の２引数コンストラクタが deprecated になったので、代わりに３引数コンストラクタを利用する
   - @melpon
+- [UPDATE] macOS Unity Editor とのシンボル衝突を回避する
+  - Unity Editor 6000.3 がエクスポートする `asio_detail_posix_thread_function` と
+     Boost.Asio の同名の `extern "C"` 関数が衝突し、 Sora インスタンス破棄時に
+    SIGSEGV が発生する問題を修正する
+  - `BOOST_ASIO_ENABLE_VERSION_NAMESPACE` を有効化し、
+    `BOOST_ASIO_VERSIONED_NAME` で生成される関数名にバージョン識別子を付加することで
+    シンボル名を変えて衝突を回避する
+  - 本問題は sora-cpp-sdk を Boost 1.91 にアップグレードした際に
+    `boost_asio_detail_posix_thread_function` から `asio_detail_posix_thread_function`
+    への関数名変更がトリガーとなり顕在化した
+  - 本問題は macOS で発見したが、 `BOOST_ASIO_ENABLE_VERSION_NAMESPACE` は
+    全プラットフォームで有効化する
+  - @torikizi
 - [FIX] カスタムエンジンが複数ある場合、`GetVideoCodecCapability()` で重複したエンジンが返されるのを修正
   - @melpon
 - [FIX] `#if USE_VPL_ENCODER` と `#if defined(USE_VPL_ENCODER)` の不一致を修正する

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -136,6 +136,7 @@ target_sources(sora
 )
 
 target_compile_definitions(sora PRIVATE ${SORA_TARGET_DEF})
+target_compile_definitions(sora PUBLIC BOOST_ASIO_ENABLE_VERSION_NAMESPACE)
 
 set(BUNDLE_STATIC_LIBS)
 


### PR DESCRIPTION
Sora Unity SDK の検証中に発見された問題を修正します。
macOS の Unity Editor でのみ再現していたクラッシュ問題をこの対応で修正します。
この修正でBoost.Asio のシンボル名にバージョン名前空間を付与し、Unity Editor が利用する Boost.Asio のシンボルとの衝突を回避します。