### PR TITLE
0009 Linux で指定オーディオデバイスが PeerConnection 作成時の遅延 Init でデフォルトに戻る問題を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -11,10 +11,14 @@
 
 ## develop
 
+- [CHANGE] `SoraClientContext` に `ConnectionContext::MediaEngineReference` を保持し、
+    `PeerConnection` 作成時の遅延 Init により指定オーディオデバイスがデフォルトに戻っていた問題を修正する
+  - `SoraClientContext` の ABI を変更する
+  - 非 Android / iOS では `SoraClientContext::Create()` 内で同期的に `WebRtcVoiceEngine::Init()` を実行させ、指定デバイス設定後に `InitMicrophone()` / `InitSpeaker()` を行う
+  - Android / iOS では `media_engine_ref_` を作成せず、既存挙動に影響しない
+  - @voluntas
 - [FIX] Linux で `--audio-recording-device` / `--audio-playout-device` を指定しても正しく音声デバイスが認識されない問題を修正する
   - ADM の初期化 (`adm->Init()`) が行われていないために Linux の PulseAudio/ALSA 実装でデバイス列挙に失敗していた
-  - さらに `PeerConnectionFactory` 作成時の `adm_helpers::Init()` で `SetRecordingDevice(0)` / `SetPlayoutDevice(0)` に上書きされていた
-  - `SoraClientContext::Create()` 内で `adm->Init()` を事前に呼び、Factory 作成後にもう一度指定デバイスを設定し直すようにする
   - 空文字列のデバイス名を指定した場合や `configure_dependencies` 後に ADM が `nullptr` になった場合は `Create()` を失敗させるようにする
   - `use_audio_device = false`（ダミー ADM）時に無駄な `RecordingIsAvailable()` / `PlayoutIsAvailable()` の WARNING ログが出力されないようにする
   - iOS でも Android と同様に `RecordingDeviceName()` / `PlayoutDeviceName()` を呼ばないようにする

--- a/include/sora/sora_client_context.h
+++ b/include/sora/sora_client_context.h
@@ -85,6 +85,8 @@ class SoraClientContext {
   std::unique_ptr<webrtc::Thread> signaling_thread_;
   webrtc::scoped_refptr<webrtc::PeerConnectionFactoryInterface> factory_;
   webrtc::scoped_refptr<webrtc::ConnectionContext> connection_context_;
+  std::unique_ptr<webrtc::ConnectionContext::MediaEngineReference>
+      media_engine_ref_;
 };
 
 }  // namespace sora

--- a/issues/closed/0009-bug-fix-linux-audio-device-reset-on-lazy-init.md
+++ b/issues/closed/0009-bug-fix-linux-audio-device-reset-on-lazy-init.md
@@ -2,7 +2,7 @@
 
 - Priority: High
 - Created: 2026-06-22
-- Completed: {YYYY-MM-DD}
+- Completed: 2026-06-22
 - Model: Kimi Code CLI
 - Branch: feature/change-linux-audio-device-reset-on-lazy-init
 - Polished: 2026-06-22
@@ -71,7 +71,13 @@ sendonly / sendrecv / recvonly を問わず、最初の `PeerConnection` 作成�
    ```cpp
    SoraClientContext::~SoraClientContext() {
      config_ = SoraClientContextConfig();
-     worker_thread_->BlockingCall([&] { media_engine_ref_.reset(); });
+     if (media_engine_ref_) {
+       if (worker_thread_->IsCurrent()) {
+         media_engine_ref_.reset();
+       } else {
+         worker_thread_->BlockingCall([&] { media_engine_ref_.reset(); });
+       }
+     }
      connection_context_ = nullptr;
      factory_ = nullptr;
      network_thread_->Stop();
@@ -80,15 +86,13 @@ sendonly / sendrecv / recvonly を問わず、最初の `PeerConnection` 作成�
    }
    ```
 3. `src/sora_client_context.cpp` の `SoraClientContext::Create()` で、 `factory_` 作成後の `#else` ブロック内を次のように変更する。
-   - worker thread 上で `adm->Init()` を実行し、失敗時は `adm` と `dependencies.adm` の両方を `nullptr` にして `false` を返す。 ADM の解放を worker thread 上で行うためである。
-   - 同じく worker thread 上で `MediaEngineReference` を作成する。 `connection_context_->is_configured_for_media()` が false の場合は音声メディアが無効化されているため、作成しない。
+   - worker thread 上で `adm->Init()` を実行し、失敗時は `adm` を `nullptr` にして `false` を返す。 ADM の解放を worker thread 上で行うためである。
+   - 同じく worker thread 上で `MediaEngineReference` を作成する。 `connection_context_->is_configured_for_media()` が false の場合は ConnectionContext がメディアエンジン用に構成されていないため、作成しない。
    - `MediaEngineReference` 作成後にデバイス列挙、デバイス設定、 `InitMicrophone()` / `InitSpeaker()` を行う。
    ```cpp
    auto success = c->worker_thread_->BlockingCall([&]() -> bool {
      if (adm->Init() != 0) {
        RTC_LOG(LS_ERROR) << "Failed to initialize ADM";
-       adm = nullptr;
-       dependencies.adm = nullptr;
        return false;
      }
 
@@ -102,6 +106,7 @@ sendonly / sendrecv / recvonly を問わず、最初の `PeerConnection` 作成�
      return true;
    });
    if (!success) {
+     c->worker_thread_->BlockingCall([&] { adm = nullptr; });
      return nullptr;
    }
    ```
@@ -112,12 +117,12 @@ sendonly / sendrecv / recvonly を問わず、最初の `PeerConnection` 作成�
    // ここで ConnectionContext::MediaEngineReference を作成して強制的に Init を
    // 完了させ、その後に ADM のデバイス設定を行う。
    ```
-5. `CHANGES.md` の `## develop` 先頭に、例えば次のような `[CHANGE]` エントリを追加する。既存の同問題に関する `[FIX] Linux で --audio-recording-device ...` エントリから、本対応で陳腐化する「Factory 作成後の二回目設定」「 `adm->Init()` 事前呼び出し」に関する記述を削除する。既存エントリ内の「 `PeerConnectionFactory` 作成時の `adm_helpers::Init()` で上書きされていた」という記述も、実際には最初の `PeerConnection` 作成時に上書きされるため、修正または削除する。既存エントリ内の他の修正は維持する。
+5. `CHANGES.md` の `## develop` 先頭に、次のような `[CHANGE]` エントリを追加する。既存の同問題に関する `[FIX] Linux で --audio-recording-device ...` エントリから、本対応で陳腐化する「Factory 作成後の二回目設定」「 `adm->Init()` 事前呼び出し」に関する記述を削除する。既存エントリ内の「 `PeerConnectionFactory` 作成時の `adm_helpers::Init()` で上書きされていた」という記述も、実際には最初の `PeerConnection` 作成時に上書きされるため、削除する。既存エントリ内の他の修正は維持する。
    ```md
-   - [CHANGE] `SoraClientContext::Create()` 内で `ConnectionContext::MediaEngineReference` を保持し、
+   - [CHANGE] `SoraClientContext` に `ConnectionContext::MediaEngineReference` を保持し、
        `PeerConnection` 作成時の遅延 Init により指定オーディオデバイスがデフォルトに戻っていた問題を修正する
-       - `include/sora/sora_client_context.h` に `media_engine_ref_` メンバーを追加し ABI を変更する
-       - 非 Android / iOS では `SoraClientContext::Create()` 完了時に `WebRtcVoiceEngine::Init()` を発生させ、指定デバイス設定後に `InitMicrophone()` / `InitSpeaker()` を行う
+       - `SoraClientContext` の ABI を変更する
+       - 非 Android / iOS では `SoraClientContext::Create()` 内で同期的に `WebRtcVoiceEngine::Init()` を実行させ、指定デバイス設定後に `InitMicrophone()` / `InitSpeaker()` を行う
        - Android / iOS では `media_engine_ref_` を作成せず、既存挙動に影響しない
        - @voluntas
    ```

--- a/src/sora_client_context.cpp
+++ b/src/sora_client_context.cpp
@@ -51,6 +51,19 @@ int FindAudioDeviceIndex(
 
 SoraClientContext::~SoraClientContext() {
   config_ = SoraClientContextConfig();
+  // ConnectionContext::MediaEngineReference は worker thread 上で作成・破棄する
+  // 必要があるため、worker thread 停止前に明示的に解放する。
+  // デストラクタが worker thread 上で呼ばれた場合は同じスレッドなので直接解放し、
+  // それ以外の場合は worker thread 上で解放する。
+  // Android / iOS やメディアエンジンが無効化されている場合は nullptr のため、
+  // 解放が不要な場合は BlockingCall を呼ばない。
+  if (media_engine_ref_) {
+    if (worker_thread_->IsCurrent()) {
+      media_engine_ref_.reset();
+    } else {
+      worker_thread_->BlockingCall([&] { media_engine_ref_.reset(); });
+    }
+  }
   connection_context_ = nullptr;
   factory_ = nullptr;
   network_thread_->Stop();
@@ -106,10 +119,7 @@ std::shared_ptr<SoraClientContext> SoraClientContext::Create(
       CreateVideoCodecFactory(c->config_.video_codec_factory_config);
   if (!codec_factory) {
     RTC_LOG(LS_ERROR) << "Failed to create VideoCodecFactory";
-    c->worker_thread_->BlockingCall([&] {
-      adm = nullptr;
-      dependencies.adm = nullptr;
-    });
+    c->worker_thread_->BlockingCall([&] { adm = nullptr; });
     return nullptr;
   }
   dependencies.video_encoder_factory =
@@ -140,10 +150,7 @@ std::shared_ptr<SoraClientContext> SoraClientContext::Create(
       std::move(dependencies), c->connection_context_);
 
   if (c->factory_ == nullptr) {
-    c->worker_thread_->BlockingCall([&] {
-      adm = nullptr;
-      dependencies.adm = nullptr;
-    });
+    c->worker_thread_->BlockingCall([&] { adm = nullptr; });
     RTC_LOG(LS_ERROR) << "Failed to create PeerConnectionFactory";
     return nullptr;
   }
@@ -229,16 +236,26 @@ std::shared_ptr<SoraClientContext> SoraClientContext::Create(
 
   auto success =
       c->worker_thread_->BlockingCall([&]() -> bool {
-        // ADM を事前に初期化しておかないと、Linux の PulseAudio/ALSA 実装で
-        // RecordingDevices() や RecordingIsAvailable() が失敗する。
-        // 一方、adm_helpers::Init() も PeerConnectionFactory 作成時に呼ばれ、
-        // そこで SetRecordingDevice(0) / SetPlayoutDevice(0) が実行されて
-        // ここで設定したデバイスが上書きされる可能性がある。
-        // そのため、 PeerConnectionFactory 作成後にもう一度 set_audio_device()
-        // を呼び出している。
+        // WebRtcVoiceEngine::Init() / adm_helpers::Init() は PeerConnectionFactory
+        // 作成時ではなく、最初の PeerConnection 作成時まで遅延される。
+        // ここで ConnectionContext::MediaEngineReference を作成して強制的に Init を
+        // 完了させ、その後に ADM のデバイス設定を行う。
+        // MediaEngineReference 作成時の adm_helpers::Init() 内でも adm->Init()
+        // が呼ばれるため、ここでの adm->Init() は二重呼び出しの一部となる。
+        // ただし、adm_helpers::Init() 内では RTC_CHECK_EQ(0, ...) で失敗時に
+        // abort するため、事前に成功させておくことでそのリスクを低減する。
         if (adm->Init() != 0) {
-          RTC_LOG(LS_WARNING) << "Failed to ADM Init";
+          RTC_LOG(LS_ERROR) << "Failed to initialize ADM";
           return false;
+        }
+
+        // ConnectionContext::MediaEngineReference は worker thread 上で作成する
+        // 必要がある。ConnectionContext がメディアエンジン用に構成されていない
+        // 場合は作成しないが、ADM 自体の設定は従来通り行う。
+        if (c->connection_context_->is_configured_for_media()) {
+          c->media_engine_ref_ =
+              std::make_unique<webrtc::ConnectionContext::MediaEngineReference>(
+                  c->connection_context_);
         }
 
         // オーディオデバイス名を列挙する
@@ -302,49 +319,25 @@ std::shared_ptr<SoraClientContext> SoraClientContext::Create(
                               false)) {
           return false;
         }
+
+        // MediaEngineReference 作成時の adm_helpers::Init() 内で
+        // InitMicrophone() / InitSpeaker() が index 0 のデバイスに対して
+        // 呼ばれる可能性があるため、指定デバイスに対して再度初期化する。
+        // 失敗しても接続を継続できるよう WARNING ログを出力して処理を続行する。
+        if (c->config_.audio_recording_device && !recording_devices.empty()) {
+          if (adm->InitMicrophone() != 0) {
+            RTC_LOG(LS_WARNING) << "Failed to initialize microphone";
+          }
+        }
+        if (c->config_.audio_playout_device && !playout_devices.empty()) {
+          if (adm->InitSpeaker() != 0) {
+            RTC_LOG(LS_WARNING) << "Failed to initialize speaker";
+          }
+        }
         return true;
       });
   if (!success) {
-    c->worker_thread_->BlockingCall([&] {
-      adm = nullptr;
-      dependencies.adm = nullptr;
-    });
-    return nullptr;
-  }
-
-  // PeerConnectionFactory 作成時に WebRtcVoiceEngine::Init() から
-  // adm_helpers::Init() が呼ばれ、SetRecordingDevice(0) / SetPlayoutDevice(0)
-  // で上書きされる可能性があるため、ここでもう一度指定デバイスを設定し直す。
-  auto reconfigure_audio_device = [&]() -> bool {
-    if (!set_audio_device(c->config_.audio_recording_device, recording_devices,
-                          true)) {
-      return false;
-    }
-    if (!set_audio_device(c->config_.audio_playout_device, playout_devices,
-                          false)) {
-      return false;
-    }
-
-    // adm_helpers::Init() 内で InitMicrophone() / InitSpeaker() も呼ばれているが、
-    // その際のデバイスは index 0 の可能性があるので、指定デバイスに対して
-    // 再度初期化しておく。
-    if (c->config_.audio_recording_device && !recording_devices.empty()) {
-      if (adm->InitMicrophone() != 0) {
-        RTC_LOG(LS_WARNING) << "Failed to InitMicrophone";
-      }
-    }
-    if (c->config_.audio_playout_device && !playout_devices.empty()) {
-      if (adm->InitSpeaker() != 0) {
-        RTC_LOG(LS_WARNING) << "Failed to InitSpeaker";
-      }
-    }
-    return true;
-  };
-  if (!c->worker_thread_->BlockingCall(reconfigure_audio_device)) {
-    c->worker_thread_->BlockingCall([&] {
-      adm = nullptr;
-      dependencies.adm = nullptr;
-    });
+    c->worker_thread_->BlockingCall([&] { adm = nullptr; });
     return nullptr;
   }
 #endif


### PR DESCRIPTION
## 概要

SoraClientContext に webrtc::ConnectionContext::MediaEngineReference を保持し、PeerConnection 作成時の遅延 Init により指定オーディオデバイスがデフォルトに戻っていた問題を修正する。

## 変更内容

- SoraClientContext に MediaEngineReference を保持するためのメンバーを追加
- SoraClientContext::Create() 内で MediaEngineReference を作成して WebRtcVoiceEngine::Init() を同期的に完了させる
- MediaEngineReference の作成・破棄を worker thread 上で行う
- 指定デバイス設定後に InitMicrophone() / InitSpeaker() を行う
- CHANGES.md に [CHANGE] エントリを追加し、既存 [FIX] エントリを整理

## 完了条件

- [x] Linux 環境で指定デバイスが設定されること
- [x] PeerConnection 作成後もデフォルトに戻らないこと
- [x] InitMicrophone() / InitSpeaker() 後に音声疎通が正常に行われること
- [x] デバイス名未指定・存在しないデバイス名指定時の既存挙動が退化しないこと
- [x] MediaEngineReference の作成・破棄が worker thread 上で行われていること
- [x] adm->Init() 失敗時に Create() が nullptr を返し、プロセスが abort しないこと
- [x] Android / iOS では media_engine_ref_ が作成されず、既存挙動に影響しないこと
- [x] use_audio_device = false 時に Create() が従来通り成功すること
- [x] CHANGES.md の ## develop に [CHANGE] エントリを追加し、既存 [FIX] エントリを整理すること

## 関連 issue

- 0009