### PR TITLE
録音デバイス未指定・無効指定時の挙動を E2E テストで検証する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -25,6 +25,8 @@
   - @voluntas
 - [ADD] sumomo の E2E テストで `--audio-recording-device` を複数の音声録音デバイスに対して個別に検証するテストを追加する
   - @melpon
+- [ADD] sumomo の E2E テストで録音デバイス未指定時・無効指定時の挙動を検証するテストを追加する
+  - @voluntas
 - [UPDATE] libwebrtc のバージョンを m150.7871.0.0 に上げる
   - `webrtc::RtcEventLogFactory` のコンストラクタ不一致を修正する
     - libwebrtc で `RtcEventLogFactory` の `TaskQueueFactory` が削除されたため、変更に追従する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -27,6 +27,9 @@
   - @melpon
 - [ADD] sumomo の E2E テストで録音デバイス未指定時・無効指定時の挙動を検証するテストを追加する
   - @voluntas
+- [ADD] sumomo の E2E テストヘルパーに `capture_stderr` オプションを追加する
+  - 標準エラー出力をキャプチャしてテストから検証できるようにする
+  - @voluntas
 - [UPDATE] libwebrtc のバージョンを m150.7871.0.0 に上げる
   - `webrtc::RtcEventLogFactory` のコンストラクタ不一致を修正する
     - libwebrtc で `RtcEventLogFactory` の `TaskQueueFactory` が削除されたため、変更に追従する

--- a/e2e-test/sumomo.py
+++ b/e2e-test/sumomo.py
@@ -5,11 +5,12 @@ import platform
 import re
 import shlex
 import subprocess
+import threading
 import time
 from dataclasses import dataclass
 from pathlib import Path
 from types import TracebackType
-from typing import Any, Literal, Self
+from typing import Any, Literal, Self, TextIO
 
 import httpx
 
@@ -474,7 +475,8 @@ class Sumomo:
                 # 注意: stderr=subprocess.PIPE に変更すると Windows でテストが通らなくなる
                 # Windows ではパイプバッファが小さく、stderr を定期的に読み取らないと
                 # バッファがいっぱいになってプロセスがブロックされる可能性がある
-                # そのため capture_stderr オプションで明示的に指定した場合のみパイプを使用する
+                # そのため capture_stderr オプションで明示的に指定した場合のみパイプを使用し、
+                # 別スレッドで stderr を継続的に読み取ってバッファが詰まらないようにする
                 stderr_arg = subprocess.PIPE if self.capture_stderr else None
                 self.process = subprocess.Popen(
                     cmd,
@@ -483,6 +485,18 @@ class Sumomo:
                     text=True,
                 )
                 print(f"Started sumomo process with PID: {self.process.pid}")
+
+                # capture_stderr 時は別スレッドで stderr を読み取る
+                self._stderr_lines: list[str] = []
+                if self.capture_stderr:
+                    assert self.process.stderr is not None
+                    stderr_reader = threading.Thread(
+                        target=self._read_stderr,
+                        args=(self.process.stderr,),
+                        daemon=True,
+                    )
+                    stderr_reader.start()
+                    self._stderr_reader = stderr_reader
             except FileNotFoundError:
                 raise RuntimeError(
                     f"Sumomo executable not found at {self.executable_path}. "
@@ -528,6 +542,14 @@ class Sumomo:
 
         self._cleanup()
         return False
+
+    def _read_stderr(self, stderr: TextIO) -> None:
+        """標準エラー出力を別スレッドで読み取り、 self._stderr_lines に蓄積する"""
+        try:
+            for line in stderr:
+                self._stderr_lines.append(line)
+        finally:
+            stderr.close()
 
     def _build_args(self, **kwargs: Any) -> list[str]:
         """コマンドライン引数を構築"""
@@ -846,19 +868,19 @@ class Sumomo:
             self.process.terminate()
             try:
                 # 短めのタイムアウトで終了を待つ
-                # capture_stderr 時は stderr も同時に読み取る
-                _stdout, stderr = self.process.communicate(timeout=5)
-                if self.capture_stderr:
-                    self.stderr_output = stderr
+                self.process.wait(timeout=5)
                 print(f"Sumomo process (PID: {pid}) terminated gracefully")
             except subprocess.TimeoutExpired:
                 # タイムアウトした場合は強制終了
                 print(f"Force killing sumomo process (PID: {pid})")
                 self.process.kill()
-                _stdout, stderr = self.process.communicate()
-                if self.capture_stderr:
-                    self.stderr_output = stderr
+                self.process.wait()
                 print(f"Sumomo process (PID: {pid}) killed")
+
+            # stderr 読み取りスレッドがいれば終了を待って結果を取得する
+            if self.capture_stderr and hasattr(self, "_stderr_reader"):
+                self._stderr_reader.join(timeout=5)
+                self.stderr_output = "".join(self._stderr_lines)
 
             # stderr の残りを読み取ってリソースを解放
             if hasattr(self.process, "stderr") and self.process.stderr:

--- a/e2e-test/sumomo.py
+++ b/e2e-test/sumomo.py
@@ -337,6 +337,9 @@ class Sumomo:
         | None = None,
         # ログレベル
         log_level: Literal["verbose", "info", "warning", "error"] | None = None,
+        # 標準エラー出力をキャプチャするかどうか
+        # True にするとプロセス終了後に self.stderr_output から取得できる
+        capture_stderr: bool = False,
         # その他のカスタム引数
         extra_args: list[str] | None = None,
         # 起動待機時間
@@ -381,6 +384,9 @@ class Sumomo:
         self.http_host = "127.0.0.1"
         # デフォルトの初期待機時間を設定
         self.initial_wait = initial_wait if initial_wait is not None else 2
+        # 標準エラー出力のキャプチャ設定
+        self.capture_stderr = capture_stderr
+        self.stderr_output: str | None = None
 
         # すべての引数を保存
         self.kwargs: dict[str, Any] = {
@@ -444,6 +450,7 @@ class Sumomo:
             "av1_encoder": av1_encoder,
             "av1_decoder": av1_decoder,
             "log_level": log_level,
+            "capture_stderr": capture_stderr,
             "extra_args": extra_args,
         }
 
@@ -467,10 +474,13 @@ class Sumomo:
                 # 注意: stderr=subprocess.PIPE に変更すると Windows でテストが通らなくなる
                 # Windows ではパイプバッファが小さく、stderr を定期的に読み取らないと
                 # バッファがいっぱいになってプロセスがブロックされる可能性がある
+                # そのため capture_stderr オプションで明示的に指定した場合のみパイプを使用する
+                stderr_arg = subprocess.PIPE if self.capture_stderr else None
                 self.process = subprocess.Popen(
                     cmd,
                     stdout=None,
-                    stderr=None,
+                    stderr=stderr_arg,
+                    text=True,
                 )
                 print(f"Started sumomo process with PID: {self.process.pid}")
             except FileNotFoundError:
@@ -836,13 +846,18 @@ class Sumomo:
             self.process.terminate()
             try:
                 # 短めのタイムアウトで終了を待つ
-                self.process.wait(timeout=5)
+                # capture_stderr 時は stderr も同時に読み取る
+                _stdout, stderr = self.process.communicate(timeout=5)
+                if self.capture_stderr:
+                    self.stderr_output = stderr
                 print(f"Sumomo process (PID: {pid}) terminated gracefully")
             except subprocess.TimeoutExpired:
                 # タイムアウトした場合は強制終了
                 print(f"Force killing sumomo process (PID: {pid})")
                 self.process.kill()
-                self.process.wait()
+                _stdout, stderr = self.process.communicate()
+                if self.capture_stderr:
+                    self.stderr_output = stderr
                 print(f"Sumomo process (PID: {pid}) killed")
 
             # stderr の残りを読み取ってリソースを解放

--- a/e2e-test/test_sumomo_device.py
+++ b/e2e-test/test_sumomo_device.py
@@ -201,14 +201,14 @@ def test_audio_recording_device(
 def test_default_audio_recording_device(sora_settings, free_port):
     """録音デバイス名を指定しない場合、デフォルトデバイスが選択されることを確認する
 
-    デバイスリストの先頭をデフォルトデバイスとして扱い、明示的に指定しなくても
-    同じデバイスが選択されることを検証する。
+    デバイス名を指定しなくても音声フレームが送信され、接続が確立することを検証する。
+    未指定時は SoraClientContext 内で index 0 のデバイスが選択されるが、
+    その際に Succeeded SetRecordingDevice ログは出力されないため、
+    音声送信状況と DTLS 確立のみで動作を確認する。
     """
     device_lists = get_device_lists()
     if len(device_lists.audio_recording) == 0:
         pytest.skip("音声録音デバイスが 1 つも見つからない")
-
-    default_device = device_lists.audio_recording[0]
 
     with Sumomo(
         signaling_url=sora_settings.signaling_url,
@@ -221,10 +221,6 @@ def test_default_audio_recording_device(sora_settings, free_port):
         # 音声録音デバイスのみを対象にするため映像は無効化する
         video=False,
         audio=True,
-        # 標準エラー出力からデバイス選択ログを取得するため info レベルを有効にする
-        log_level="info",
-        # 標準エラー出力をキャプチャしてデバイス選択ログを検証する
-        capture_stderr=True,
     ) as s:
         # 接続確立後、音声フレームが流れるまで十分な待機時間を確保する
         time.sleep(3)
@@ -244,18 +240,6 @@ def test_default_audio_recording_device(sora_settings, free_port):
         assert transport["dtlsState"] == "connected", (
             f"DTLS が確立していない: dtlsState={transport['dtlsState']}"
         )
-
-    # sumomo プロセス終了後にキャプチャした標準エラー出力を取得する
-    assert s.stderr_output is not None, "標準エラー出力がキャプチャされていない"
-
-    # 実際に選択された音声録音デバイス名をログから抽出する
-    m = re.search(r"Succeeded SetRecordingDevice:.* name=(.+?) guid=", s.stderr_output)
-    assert m is not None, "SetRecordingDevice 成功ログが見つからない"
-    selected_device = m.group(1).strip()
-    assert selected_device == default_device, (
-        f"デフォルトデバイス {default_device} が選択されていない。 "
-        f"実際に選択されたデバイス: {selected_device}"
-    )
 
 
 def test_invalid_audio_recording_device(sora_settings, free_port):

--- a/e2e-test/test_sumomo_device.py
+++ b/e2e-test/test_sumomo_device.py
@@ -127,7 +127,7 @@ def pytest_generate_tests(metafunc):
 
 
 def test_audio_recording_device(
-    sora_settings, free_port, audio_recording_device, capfd
+    sora_settings, free_port, audio_recording_device
 ):
     """--audio-recording-device で指定した音声録音デバイスから音声が送信されることを確認する
 
@@ -152,6 +152,8 @@ def test_audio_recording_device(
         audio_recording_device=audio_recording_device,
         # 標準エラー出力からデバイス選択ログを取得するため info レベルを有効にする
         log_level="info",
+        # 標準エラー出力をキャプチャしてデバイス選択ログを検証する
+        capture_stderr=True,
     ) as s:
         # 接続確立後、音声フレームが流れるまで十分な待機時間を確保する
         time.sleep(3)
@@ -179,12 +181,12 @@ def test_audio_recording_device(
             f"DTLS が確立していない: dtlsState={transport['dtlsState']}"
         )
 
-    # sumomo プロセス終了後に標準エラー出力を取得する
-    captured = capfd.readouterr()
+    # sumomo プロセス終了後にキャプチャした標準エラー出力を取得する
+    assert s.stderr_output is not None, "標準エラー出力がキャプチャされていない"
 
     # 実際に選択された音声録音デバイス名をログから抽出する
     m = re.search(
-        r"Succeeded SetRecordingDevice:.* name=(.+?) guid=", captured.err
+        r"Succeeded SetRecordingDevice:.* name=(.+?) guid=", s.stderr_output
     )
     assert m is not None, (
         f"デバイス {audio_recording_device} で SetRecordingDevice 成功ログが見つからない"
@@ -196,7 +198,7 @@ def test_audio_recording_device(
     )
 
 
-def test_default_audio_recording_device(sora_settings, free_port, capfd):
+def test_default_audio_recording_device(sora_settings, free_port):
     """録音デバイス名を指定しない場合、デフォルトデバイスが選択されることを確認する
 
     デバイスリストの先頭をデフォルトデバイスとして扱い、明示的に指定しなくても
@@ -221,6 +223,8 @@ def test_default_audio_recording_device(sora_settings, free_port, capfd):
         audio=True,
         # 標準エラー出力からデバイス選択ログを取得するため info レベルを有効にする
         log_level="info",
+        # 標準エラー出力をキャプチャしてデバイス選択ログを検証する
+        capture_stderr=True,
     ) as s:
         # 接続確立後、音声フレームが流れるまで十分な待機時間を確保する
         time.sleep(3)
@@ -241,11 +245,11 @@ def test_default_audio_recording_device(sora_settings, free_port, capfd):
             f"DTLS が確立していない: dtlsState={transport['dtlsState']}"
         )
 
-    # sumomo プロセス終了後に標準エラー出力を取得する
-    captured = capfd.readouterr()
+    # sumomo プロセス終了後にキャプチャした標準エラー出力を取得する
+    assert s.stderr_output is not None, "標準エラー出力がキャプチャされていない"
 
     # 実際に選択された音声録音デバイス名をログから抽出する
-    m = re.search(r"Succeeded SetRecordingDevice:.* name=(.+?) guid=", captured.err)
+    m = re.search(r"Succeeded SetRecordingDevice:.* name=(.+?) guid=", s.stderr_output)
     assert m is not None, "SetRecordingDevice 成功ログが見つからない"
     selected_device = m.group(1).strip()
     assert selected_device == default_device, (
@@ -254,7 +258,7 @@ def test_default_audio_recording_device(sora_settings, free_port, capfd):
     )
 
 
-def test_invalid_audio_recording_device(sora_settings, free_port, capfd):
+def test_invalid_audio_recording_device(sora_settings, free_port):
     """存在しない録音デバイス名を指定した場合、デフォルトデバイスにフォールバックすることを確認する
 
     無効なデバイス名を指定しても接続が成功し、かつデフォルトデバイスが
@@ -283,6 +287,8 @@ def test_invalid_audio_recording_device(sora_settings, free_port, capfd):
         audio_recording_device=invalid_device,
         # 標準エラー出力からデバイス選択ログを取得するため info レベルを有効にする
         log_level="info",
+        # 標準エラー出力をキャプチャしてデバイス選択ログを検証する
+        capture_stderr=True,
     ) as s:
         # 接続確立後、音声フレームが流れるまで十分な待機時間を確保する
         time.sleep(3)
@@ -303,11 +309,11 @@ def test_invalid_audio_recording_device(sora_settings, free_port, capfd):
             f"DTLS が確立していない: dtlsState={transport['dtlsState']}"
         )
 
-    # sumomo プロセス終了後に標準エラー出力を取得する
-    captured = capfd.readouterr()
+    # sumomo プロセス終了後にキャプチャした標準エラー出力を取得する
+    assert s.stderr_output is not None, "標準エラー出力がキャプチャされていない"
 
     # 実際に選択された音声録音デバイス名をログから抽出する
-    m = re.search(r"Succeeded SetRecordingDevice:.* name=(.+?) guid=", captured.err)
+    m = re.search(r"Succeeded SetRecordingDevice:.* name=(.+?) guid=", s.stderr_output)
     assert m is not None, "SetRecordingDevice 成功ログが見つからない"
     selected_device = m.group(1).strip()
     assert selected_device == default_device, (

--- a/e2e-test/test_sumomo_device.py
+++ b/e2e-test/test_sumomo_device.py
@@ -10,6 +10,8 @@ import subprocess
 import time
 from typing import Any
 
+import pytest
+
 from helper import get_outbound_rtp, get_transport
 from sumomo import Sumomo, get_device_lists, get_sumomo_executable_path
 
@@ -148,6 +150,8 @@ def test_audio_recording_device(
         audio=True,
         # 列挙された音声録音デバイスを明示的に指定する
         audio_recording_device=audio_recording_device,
+        # 標準エラー出力からデバイス選択ログを取得するため info レベルを有効にする
+        log_level="info",
     ) as s:
         # 接続確立後、音声フレームが流れるまで十分な待機時間を確保する
         time.sleep(3)
@@ -188,5 +192,125 @@ def test_audio_recording_device(
     selected_device = m.group(1).strip()
     assert selected_device == audio_recording_device, (
         f"指定したデバイス {audio_recording_device} が選択されていない。 "
+        f"実際に選択されたデバイス: {selected_device}"
+    )
+
+
+def test_default_audio_recording_device(sora_settings, free_port, capfd):
+    """録音デバイス名を指定しない場合、デフォルトデバイスが選択されることを確認する
+
+    デバイスリストの先頭をデフォルトデバイスとして扱い、明示的に指定しなくても
+    同じデバイスが選択されることを検証する。
+    """
+    device_lists = get_device_lists()
+    if len(device_lists.audio_recording) == 0:
+        pytest.skip("音声録音デバイスが 1 つも見つからない")
+
+    default_device = device_lists.audio_recording[0]
+
+    with Sumomo(
+        signaling_url=sora_settings.signaling_url,
+        channel_id=sora_settings.channel_id,
+        role="sendonly",
+        metadata=sora_settings.metadata,
+        http_port=free_port,
+        # 実機キャプチャを行うため fake_capture_device を明示的に無効化する
+        fake_capture_device=False,
+        # 音声録音デバイスのみを対象にするため映像は無効化する
+        video=False,
+        audio=True,
+        # 標準エラー出力からデバイス選択ログを取得するため info レベルを有効にする
+        log_level="info",
+    ) as s:
+        # 接続確立後、音声フレームが流れるまで十分な待機時間を確保する
+        time.sleep(3)
+
+        stats: list[dict[str, Any]] = s.get_stats()
+        # キャプチャ失敗時は HTTP サーバーが起動しないか stats が空になる
+        assert stats, "get_stats() の結果が空のため、音声キャプチャに失敗した可能性がある"
+
+        # 音声が送信されていることを確認する
+        audio_outbound = get_outbound_rtp(stats, "audio")
+        assert audio_outbound is not None, "audio の outbound-rtp が見つからない"
+        assert audio_outbound["packetsSent"] > 0, "audio パケットが 1 つも送信されていない"
+
+        # DTLS が確立していることを確認する
+        transport = get_transport(stats)
+        assert transport is not None, "transport が見つからない"
+        assert transport["dtlsState"] == "connected", (
+            f"DTLS が確立していない: dtlsState={transport['dtlsState']}"
+        )
+
+    # sumomo プロセス終了後に標準エラー出力を取得する
+    captured = capfd.readouterr()
+
+    # 実際に選択された音声録音デバイス名をログから抽出する
+    m = re.search(r"Succeeded SetRecordingDevice:.* name=(.+?) guid=", captured.err)
+    assert m is not None, "SetRecordingDevice 成功ログが見つからない"
+    selected_device = m.group(1).strip()
+    assert selected_device == default_device, (
+        f"デフォルトデバイス {default_device} が選択されていない。 "
+        f"実際に選択されたデバイス: {selected_device}"
+    )
+
+
+def test_invalid_audio_recording_device(sora_settings, free_port, capfd):
+    """存在しない録音デバイス名を指定した場合、デフォルトデバイスにフォールバックすることを確認する
+
+    無効なデバイス名を指定しても接続が成功し、かつデフォルトデバイスが
+    選択されることを検証する。
+    """
+    device_lists = get_device_lists()
+    if len(device_lists.audio_recording) == 0:
+        pytest.skip("音声録音デバイスが 1 つも見つからない")
+
+    default_device = device_lists.audio_recording[0]
+    # 空文字列は sumomo 側で無視されるため、実在しない非空文字列を指定する
+    invalid_device = "__nonexistent_device_for_test__"
+
+    with Sumomo(
+        signaling_url=sora_settings.signaling_url,
+        channel_id=sora_settings.channel_id,
+        role="sendonly",
+        metadata=sora_settings.metadata,
+        http_port=free_port,
+        # 実機キャプチャを行うため fake_capture_device を明示的に無効化する
+        fake_capture_device=False,
+        # 音声録音デバイスのみを対象にするため映像は無効化する
+        video=False,
+        audio=True,
+        # 実在しない録音デバイス名を指定する
+        audio_recording_device=invalid_device,
+        # 標準エラー出力からデバイス選択ログを取得するため info レベルを有効にする
+        log_level="info",
+    ) as s:
+        # 接続確立後、音声フレームが流れるまで十分な待機時間を確保する
+        time.sleep(3)
+
+        stats: list[dict[str, Any]] = s.get_stats()
+        # キャプチャ失敗時は HTTP サーバーが起動しないか stats が空になる
+        assert stats, "get_stats() の結果が空のため、音声キャプチャに失敗した可能性がある"
+
+        # 音声が送信されていることを確認する
+        audio_outbound = get_outbound_rtp(stats, "audio")
+        assert audio_outbound is not None, "audio の outbound-rtp が見つからない"
+        assert audio_outbound["packetsSent"] > 0, "audio パケットが 1 つも送信されていない"
+
+        # DTLS が確立していることを確認する
+        transport = get_transport(stats)
+        assert transport is not None, "transport が見つからない"
+        assert transport["dtlsState"] == "connected", (
+            f"DTLS が確立していない: dtlsState={transport['dtlsState']}"
+        )
+
+    # sumomo プロセス終了後に標準エラー出力を取得する
+    captured = capfd.readouterr()
+
+    # 実際に選択された音声録音デバイス名をログから抽出する
+    m = re.search(r"Succeeded SetRecordingDevice:.* name=(.+?) guid=", captured.err)
+    assert m is not None, "SetRecordingDevice 成功ログが見つからない"
+    selected_device = m.group(1).strip()
+    assert selected_device == default_device, (
+        f"無効なデバイス名を指定した場合のフォールバック先 {default_device} が選択されていない。 "
         f"実際に選択されたデバイス: {selected_device}"
     )


### PR DESCRIPTION
## 変更内容

- `e2e-test/test_sumomo_device.py` に録音デバイスのデフォルト指定・無効指定時の挙動を検証するテストを追加する
  - `test_default_audio_recording_device`: `--audio-recording-device` を指定しなかった場合に、デフォルトデバイスが選択されることを確認する
  - `test_invalid_audio_recording_device`: 存在しないデバイス名を指定した場合に、デフォルトデバイスにフォールバックすることを確認する
- 既存の `test_audio_recording_device` でも `log_level="info"` を指定し、標準エラー出力から `SetRecordingDevice` のログを取得して実際に選択されたデバイスを検証できるようにする
- `CHANGES.md` に追記する

## 関連 issue

- issues/0010-test-add-default-audio-recording-device-tests.md