### PR TITLE
BOOST_ASIO_DISABLE_STD_ATOMIC_WAIT を PUBLIC にする

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -54,7 +54,7 @@
 - [UPDATE] cmake のバージョンを 4.3.2 にあげる
   - @torikizi
 - [UPDATE] Boost のバージョンを 1.91.0 に上げる
-  - macOS ビルドと iOS ビルドの cxxflags に `-DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT` を追加する
+  - CMakeLists.txt の macOS ビルドと iOS ビルドの `target_compile_definitions` に PUBLIC で `BOOST_ASIO_DISABLE_STD_ATOMIC_WAIT` を追加する
     - boost 1.91.0 で asio の `kqueue_reactor` 内部 mutex が `atomic_slim_mutex` (`std::atomic::wait` / `notify_one` を利用) に切り替わったが、 webrtc-build 同梱の libc++ + macOS の組み合わせで kevent から完了通知が届かず async_connect がハングする現象を確認した
     - 旧来の pthread ベース mutex 実装に戻すことで回避する
     - IPHONEOS_DEPLOYMENT_TARGET が iOS 17.4 以上の場合に発生する問題であり 14.0 でビルドしているため影響はないが、今後バージョンを上げた際の問題を回避するため macOS ビルドと同様に修正する
@@ -136,10 +136,6 @@
   - @zztkm
 - [UPDATE] Examples の cli11 のバージョンを v2.6.2 にあげる
   - @torikizi
-- [UPDATE] Examples の Boost のバージョンを 1.91.0 に上げる
-  - sumomo の macOS 向け CMake 設定に `-DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT` を追加する
-    - sora-cpp-sdk 本体側にも同じ定義が必要 (片方だけ外すと kqueue_reactor の mutex 型が TU 間で食い違って ABI ミスマッチを起こす)
-  - @voluntas @torikizi
 - [UPDATE] GitHub Actions の Homebrew/actions/setup-homebrew@master を Homebrew/actions/setup-homebrew@main に変更する
   - 2026 年 6 月 10 日以降のリリースで `Homebrew/actions/setup-homebrew` の master ブランチは無効化されるため、main ブランチを使用するように変更する
   - 参考: Homebrew/actions/setup-homebrew で、main ブランチへの移行を促す警告が表示されるようになったことを示すコミット

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -417,6 +417,14 @@ elseif (SORA_TARGET_OS STREQUAL "macos")
       _LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS
       _LIBCPP_ENABLE_NODISCARD
       _LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE
+      # Boost 1.91.0 で Asio の kqueue_reactor が atomic_slim_mutex
+      # (std::atomic::wait / notify_one ベース) に切り替わった。
+      # webrtc-build 同梱の libc++ と macOS の組み合わせで
+      # async_connect が kevent から完了通知を受け取れずハングするため、
+      # 旧来の pthread ベース mutex に戻す。
+      # PUBLIC で定義することで Sora::sora にリンクする全 TU で
+      # 定義を統一し ABI ミスマッチを防ぐ。
+      BOOST_ASIO_DISABLE_STD_ATOMIC_WAIT
   )
 
   target_link_libraries(sora
@@ -469,6 +477,14 @@ elseif (SORA_TARGET_OS STREQUAL "ios")
       _LIBCXXABI_DISABLE_VISIBILITY_ANNOTATIONS
       _LIBCPP_ENABLE_NODISCARD
       _LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE
+      # Boost 1.91.0 で Asio の kqueue_reactor が atomic_slim_mutex
+      # (std::atomic::wait / notify_one ベース) に切り替わった。
+      # webrtc-build 同梱の libc++ と iOS の組み合わせで
+      # async_connect が kevent から完了通知を受け取れずハングするため、
+      # 旧来の pthread ベース mutex に戻す。
+      # PUBLIC で定義することで Sora::sora にリンクする全 TU で
+      # 定義を統一し ABI ミスマッチを防ぐ。
+      BOOST_ASIO_DISABLE_STD_ATOMIC_WAIT
   )
 
 elseif (SORA_TARGET_OS STREQUAL "android")

--- a/examples/sumomo/run.py
+++ b/examples/sumomo/run.py
@@ -342,16 +342,6 @@ def _build(args):
                 f"-DCMAKE_C_COMPILER={os.path.join(webrtc_info.clang_dir, 'bin', 'clang')}",
                 f"-DCMAKE_CXX_COMPILER={os.path.join(webrtc_info.clang_dir, 'bin', 'clang++')}",
                 f"-DLIBCXX_INCLUDE_DIR={cmake_path(os.path.join(webrtc_info.libcxx_dir, 'include'))}",
-                # boost 1.91.0 で asio に atomic_slim_mutex が導入され、 kqueue_reactor
-                # の内部 mutex がこの実装に切り替わった。 atomic_slim_mutex は
-                # std::atomic<int>::wait / notify_one (C++20 atomic wait) を利用するが、
-                # webrtc-build 同梱の libc++ ヘッダ + 実行時 libc++ の組み合わせで
-                # macOS の async_connect が kevent から完了通知を受け取れずハングする
-                # 事象を確認したため、 旧来の pthread ベース mutex に戻すために本マクロ
-                # を定義している。 sora-cpp-sdk 本体のビルド (run.py) 側にも同じ定義が
-                # 必要 (片方だけ外すと kqueue_reactor のクラスサイズ・mutex 型が TU 間で
-                # 食い違って ABI ミスマッチを起こす)。
-                "-DCMAKE_CXX_FLAGS=-DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT",
             ]
         elif platform in ("ubuntu-22.04_x86_64", "ubuntu-24.04_x86_64"):
             cmake_args += [

--- a/run.py
+++ b/run.py
@@ -96,16 +96,6 @@ def get_common_cmake_args(
         cxxflags = [
             "-nostdinc++",
             "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE",
-            # boost 1.91.0 で asio に atomic_slim_mutex が導入され、 kqueue_reactor
-            # の内部 mutex がこの実装に切り替わった。 atomic_slim_mutex は
-            # std::atomic<int>::wait / notify_one (C++20 atomic wait) を利用するが、
-            # webrtc-build 同梱の libc++ ヘッダ + 実行時 libc++ の組み合わせで
-            # macOS の async_connect が kevent から完了通知を受け取れずハングする
-            # 事象を確認したため、 旧来の pthread ベース mutex に戻すために本マクロ
-            # を定義している。 examples/sumomo/run.py 側にも同じ定義が必要 (片方
-            # だけ外すと kqueue_reactor のクラスサイズ・mutex 型が TU 間で食い違って
-            # ABI ミスマッチを起こす)。
-            "-DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT",
         ]
         args.append(f"-DCMAKE_CXX_FLAGS={' '.join(cxxflags)}")
     if platform.target.os == "ubuntu":
@@ -172,13 +162,6 @@ def get_common_cmake_args(
         cxxflags = [
             "-nostdinc++",
             "-D_LIBCPP_HARDENING_MODE=_LIBCPP_HARDENING_MODE_EXTENSIVE",
-            # boost 1.91.0 で asio に atomic_slim_mutex が導入され、 kqueue_reactor
-            # の内部 mutex がこの実装に切り替わった。 atomic_slim_mutex は
-            # std::atomic<int>::wait / notify_one (C++20 atomic wait) を利用するが、
-            # webrtc-build 同梱の libc++ ヘッダ + 実行時 libc++ の組み合わせで
-            # iOS 17.4 以上がターゲットの場合 async_connect が kevent から完了通知を受け取れずハングする
-            # 事象を確認したため、 旧来の pthread ベース mutex に戻すために本マクロを定義している。
-            "-DBOOST_ASIO_DISABLE_STD_ATOMIC_WAIT",
         ]
         args.append(f"-DCMAKE_CXX_FLAGS={' '.join(cxxflags)}")
     if platform.target.os == "android":


### PR DESCRIPTION
run.py で設定していた `BOOST_ASIO_DISABLE_STD_ATOMIC_WAIT` を CMakeLists.txt に PUBLIC で定義するように修正します。

この変更で Sora CPP SDK を利用している各種 SDK で `BOOST_ASIO_DISABLE_STD_ATOMIC_WAIT` を定義する必要がなくなります。