### PR TITLE
registerReceiver の RECEIVER_NOT_EXPORTED 対応を Revert する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -111,8 +111,6 @@
   - @melpon
 - [FIX] Android の `SoraAudioManagerBluetooth` で `stateToString` の出力が間違っていたのを修正する
   - @melpon
-- [FIX] Android の `registerReceiver` に `RECEIVER_NOT_EXPORTED` フラグを付与する
-  - @melpon
 - [FIX] `SoraSignaling` で接続タイムアウトの値に `SoraSignalingConfig::websocket_connection_timeout` が使用されていなかったのを修正する
   - @melpon
 - [FIX] SoraVideoDecoderFactory / SoraVideoEncoderFactory の formats_ 並行アクセスによる abort を修正する

--- a/android/Sora/Sora/src/main/java/jp/shiguredo/sora/audiomanager/SoraAudioManager2.java
+++ b/android/Sora/Sora/src/main/java/jp/shiguredo/sora/audiomanager/SoraAudioManager2.java
@@ -23,8 +23,6 @@ import android.media.AudioManager;
 import android.os.Build;
 import android.util.Log;
 
-import androidx.core.content.ContextCompat;
-
 import java.util.ArrayList;
 import java.util.List;
 
@@ -98,7 +96,7 @@ class SoraAudioManager2 extends SoraAudioManagerBase {
         IntentFilter filter = new IntentFilter();
         // bluetooth SCO の状態変化を取得する
         filter.addAction(AudioManager.ACTION_SCO_AUDIO_STATE_UPDATED);
-        ContextCompat.registerReceiver(context, bluetoothHeadsetReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
+        context.registerReceiver(bluetoothHeadsetReceiver, filter);
 
         // 初期化を行った状態でデバイスの設定を行う
         updateAudioDeviceState();

--- a/android/Sora/Sora/src/main/java/jp/shiguredo/sora/audiomanager/SoraAudioManagerBase.java
+++ b/android/Sora/Sora/src/main/java/jp/shiguredo/sora/audiomanager/SoraAudioManagerBase.java
@@ -24,8 +24,6 @@ import android.media.AudioManager;
 import android.os.Build;
 import android.util.Log;
 
-import androidx.core.content.ContextCompat;
-
 abstract class SoraAudioManagerBase implements SoraAudioManager {
     private static final String TAG = "SoraAudioManager";
     protected final Context context;
@@ -100,11 +98,9 @@ abstract class SoraAudioManagerBase implements SoraAudioManager {
 
     // 有線ヘッドセットの接続を通知するレシーバーを登録する
     protected void registerWiredHeadsetReceiver() {
-        ContextCompat.registerReceiver(
-                context,
+        context.registerReceiver(
                 wiredHeadsetReceiver,
-                new IntentFilter(Intent.ACTION_HEADSET_PLUG),
-                ContextCompat.RECEIVER_NOT_EXPORTED);
+                new IntentFilter(Intent.ACTION_HEADSET_PLUG));
     }
 
     @Override

--- a/android/Sora/Sora/src/main/java/jp/shiguredo/sora/audiomanager/SoraAudioManagerBluetooth.java
+++ b/android/Sora/Sora/src/main/java/jp/shiguredo/sora/audiomanager/SoraAudioManagerBluetooth.java
@@ -25,8 +25,6 @@ import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
 
-import androidx.core.content.ContextCompat;
-
 import java.util.List;
 
 class SoraAudioManagerBluetooth {
@@ -210,7 +208,7 @@ class SoraAudioManagerBluetooth {
         filter.addAction(BluetoothHeadset.ACTION_CONNECTION_STATE_CHANGED);
         // bluetooth ヘッドセットのオーディオの状態変化を取得する
         filter.addAction(BluetoothHeadset.ACTION_AUDIO_STATE_CHANGED);
-        ContextCompat.registerReceiver(context, bluetoothHeadsetReceiver, filter, ContextCompat.RECEIVER_NOT_EXPORTED);
+        context.registerReceiver(bluetoothHeadsetReceiver, filter);
         bluetoothState = State.HEADSET_UNAVAILABLE;
     }
 


### PR DESCRIPTION
Android 14 (API 34) 以上では本変更が必要となるが、以下の理由で revert する。
- 本変更で追加される AndroidX 依存関係の導入方法について別途検討が必要であること
- Android API レベル要件への対応方針および下位互換性について別途検討が必要であること

Android API レベル要件を含めて改めて方針を検討し、対応を進める。