### PR TITLE
Boost.Beast の basic_stream.hpp の inline namespace 競合を修正する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -94,6 +94,16 @@
   - basic_stream.hpp の前方宣言を
     `BOOST_ASIO_INLINE_NAMESPACE_BEGIN` / `BOOST_ASIO_INLINE_NAMESPACE_END` で
     ラップするパッチを buildbase.py に追加する
+  - 参考: Boost.Asio 1.91 で BOOST_ASIO_ENABLE_VERSION_NAMESPACE による
+    inline namespace のバイナリバージョニングが
+    追加されたが、前方宣言を壊す可能性があるためデフォルト無効とされている
+    該当記載のある boost のドキュメント : 
+    ```
+    Added optional binary versioning using an inline namespace. ... The inline
+    namespace is disabled by default to avoid breaking existing code that forward
+    declares Asio names
+    ```
+    - リンク : https://www.boost.org/doc/libs/1_91_0/doc/html/boost_asio/history.html
   - @torikizi
 - [ADD] TURN-TLS のクライアント証明書設定に対応する
   - `SoraSignalingConfig` の `client_cert` / `client_key` を TURN-TLS にも適用する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -88,6 +88,13 @@
   - 本問題は macOS で発見したが、 `BOOST_ASIO_ENABLE_VERSION_NAMESPACE` は
     全プラットフォームで有効化する
   - @torikizi
+- [UPDATE] BOOST_ASIO_ENABLE_VERSION_NAMESPACE 有効時に Boost.Beast 1.91 の
+    basic_stream.hpp にある boost::asio::ssl::stream の前方宣言が
+    inline namespace に対応しておらずビルドエラーが発生する問題を修正する
+  - basic_stream.hpp の前方宣言を
+    `BOOST_ASIO_INLINE_NAMESPACE_BEGIN` / `BOOST_ASIO_INLINE_NAMESPACE_END` で
+    ラップするパッチを buildbase.py に追加する
+  - @torikizi
 - [ADD] TURN-TLS のクライアント証明書設定に対応する
   - `SoraSignalingConfig` の `client_cert` / `client_key` を TURN-TLS にも適用する
   - @zztkm

--- a/buildbase.py
+++ b/buildbase.py
@@ -695,6 +695,38 @@ def install_boost(
     extract(archive, output_dir=install_dir, output_dirname="boost")
 
 
+# Sora C++ SDK 2026.2.0-canary.15 以降で BOOST_ASIO_ENABLE_VERSION_NAMESPACE が有効になると
+# Boost.Asio が inline namespace (例: v103801_kmn) を使用するようになる。
+# これは異なるバージョンの Asio が同一プロセス内で共存できるようにするための機能で、
+# Unity Editor 6000.3 とのシンボル衝突回避のために有効化された。
+#
+# しかし Boost.Beast 1.91 の basic_stream.hpp には boost::asio::ssl::stream の
+# 前方宣言があり、inline namespace に対応していない。そのため version namespace が
+# 有効な環境では名前解決が曖昧になりビルドエラーが発生する。
+#
+# Boost.Asio 側でも「前方宣言を壊す可能性があるためデフォルト無効」としており、
+# デフォルト無効の設定と Beast 側の未対応の組み合わせで顕在化した問題。
+#
+# 対応: 前方宣言を BOOST_ASIO_INLINE_NAMESPACE_BEGIN / END でラップする。
+# 有効時は inline namespace 内に宣言が入り、無効時はマクロが空展開されるため、
+# どちらの設定でも正しく動作する。
+BOOST_PATCH_BEAST_INLINE_NAMESPACE = r"""
+diff --git a/boost/beast/core/basic_stream.hpp b/boost/beast/core/basic_stream.hpp
+--- a/boost/beast/core/basic_stream.hpp
++++ b/boost/beast/core/basic_stream.hpp
+@@ -33,7 +33,9 @@
+ namespace boost {
+ namespace asio {
++BOOST_ASIO_INLINE_NAMESPACE_BEGIN
+ namespace ssl {
+ template<typename> class stream;
+ } // ssl
++BOOST_ASIO_INLINE_NAMESPACE_END
+ } // asio
+ } // boost
+"""
+
+
 # 以下の問題を解決するためのパッチ
 #
 # No support for msvc-toolset 14.4x (VS 2022, 17.10.x): https://github.com/boostorg/boost/issues/914
@@ -825,6 +857,12 @@ def build_and_install_boost(
         expected_sha256=expected_sha256,
     )
     extract(archive, output_dir=build_dir, output_dirname="boost")
+
+    # basic_stream.hpp の inline namespace 競合を修正するパッチ
+    apply_patch_text(
+        BOOST_PATCH_BEAST_INLINE_NAMESPACE, os.path.join(build_dir, "boost"), 1
+    )
+
     with cd(os.path.join(build_dir, "boost")):
         if target_os == "windows":
             bootstrap = ".\\bootstrap.bat"

--- a/buildbase.py
+++ b/buildbase.py
@@ -695,7 +695,7 @@ def install_boost(
     extract(archive, output_dir=install_dir, output_dirname="boost")
 
 
-# Sora C++ SDK 2026.2.0-canary.15 以降で BOOST_ASIO_ENABLE_VERSION_NAMESPACE が有効になると
+# BOOST_ASIO_ENABLE_VERSION_NAMESPACE が有効になると
 # Boost.Asio が inline namespace (例: v103801_kmn) を使用するようになる。
 # これは異なるバージョンの Asio が同一プロセス内で共存できるようにするための機能で、
 # Unity Editor 6000.3 とのシンボル衝突回避のために有効化された。


### PR DESCRIPTION
BOOST_ASIO_ENABLE_VERSION_NAMESPACE 有効時に Boost.Beast 1.91 の basic_stream.hpp にある boost::asio::ssl::stream の前方宣言が inline namespace に対応しておらずビルドエラーが発生する問題を修正します。