### PR TITLE
test の iOS プロジェクトに Security.framework を追加する

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -203,6 +203,8 @@
   - `rtCamp/action-slack-notify@v2` を `shiguredo/github-actions/.github/actions/slack-notify@main` に置き換える
   - 通知ジョブの `runs-on` を `ubuntu-slim` に変更する
   - @miosakuma
+- [ADD] test の iOS プロジェクトに Security.framework を追加する
+  - @torikizi
 - [UPDATE] Examples の WEBRTC_BUILD_VERSION を m150.7871.3.1 にあげる
   - @torikizi @zztkm
 - [UPDATE] GitHub Actions の `macos-14` を `macos-15` に上げる

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,7 +40,7 @@
   - Linux: Ubuntu 22.04 / 24.04、Raspberry Pi OS bookworm 以降が対象、前提を満たさない環境では `ca_cert` 指定が必要
   - Windows: Windows 10 以降が対象、`ROOT` ストアに必要なルート CA がない環境では `ca_cert` 指定が必要
   - iOS: iOS 14 以降が対象、sandbox 制約により `SecTrustEvaluateWithError` に検証委譲する方式で実装
-    - `SecTrustEvaluateWithError` の利用に伴い iOS アプリのビルド時に Security.framework のリンクが必要になる
+    - `SecTrustEvaluateWithError` の利用に伴い iOS アプリのビルド時に Security.framework の追加が必要になる
   - Android: Android 10 以降が対象、Conscrypt Mainline module 経由の CA ストアと AOSP 標準パスの両方を読み込む
   - 内部フリー関数 `sora::LoadSystemSSLRootCertificates` を共通差し込み口とし、`ca_cert` 未指定時の信頼ストア構築を集約する
   - 旧ハードコード PEM（isrg_root / lets_encrypt_r3）と WebRTC `rtc_base/ssl_roots.h` 依存を完全に撤廃する

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -40,6 +40,7 @@
   - Linux: Ubuntu 22.04 / 24.04、Raspberry Pi OS bookworm 以降が対象、前提を満たさない環境では `ca_cert` 指定が必要
   - Windows: Windows 10 以降が対象、`ROOT` ストアに必要なルート CA がない環境では `ca_cert` 指定が必要
   - iOS: iOS 14 以降が対象、sandbox 制約により `SecTrustEvaluateWithError` に検証委譲する方式で実装
+    - `SecTrustEvaluateWithError` の利用に伴い iOS アプリのビルド時に Security.framework のリンクが必要になる
   - Android: Android 10 以降が対象、Conscrypt Mainline module 経由の CA ストアと AOSP 標準パスの両方を読み込む
   - 内部フリー関数 `sora::LoadSystemSSLRootCertificates` を共通差し込み口とし、`ca_cert` 未指定時の信頼ストア構築を集約する
   - 旧ハードコード PEM（isrg_root / lets_encrypt_r3）と WebRTC `rtc_base/ssl_roots.h` 依存を完全に撤廃する

--- a/test/ios/hello.xcodeproj/project.pbxproj
+++ b/test/ios/hello.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		DDBC4BC3282216350099E1F0 /* Network.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBC4BC2282216340099E1F0 /* Network.framework */; };
 		DDBC4BC7282216890099E1F0 /* GLKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DDBC4BC6282216890099E1F0 /* GLKit.framework */; };
 		E97B0C172AA9DD2600FB45B9 /* AudioOutputHelperWrapper.mm in Sources */ = {isa = PBXBuildFile; fileRef = E97B0C162AA9DD2600FB45B9 /* AudioOutputHelperWrapper.mm */; };
+		E9A1B0502CB0000000FB45C0 /* Security.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E9A1B0512CB0000000FB45C0 /* Security.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -72,6 +73,7 @@
 		DDBC4BC6282216890099E1F0 /* GLKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = GLKit.framework; path = System/Library/Frameworks/GLKit.framework; sourceTree = SDKROOT; };
 		E97B0C152AA9D44F00FB45B9 /* AudioOutputHelperWrapper.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = AudioOutputHelperWrapper.h; sourceTree = "<group>"; };
 		E97B0C162AA9DD2600FB45B9 /* AudioOutputHelperWrapper.mm */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.cpp.objcpp; path = AudioOutputHelperWrapper.mm; sourceTree = "<group>"; };
+		E9A1B0512CB0000000FB45C0 /* Security.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Security.framework; path = System/Library/Frameworks/Security.framework; sourceTree = SDKROOT; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -97,6 +99,7 @@
 				DDBC4BC7282216890099E1F0 /* GLKit.framework in Frameworks */,
 				DD76254E290AFDE100BFE6D8 /* libboost_filesystem.a in Frameworks */,
 				DDBC4BB52820F4090099E1F0 /* libsora.a in Frameworks */,
+				E9A1B0502CB0000000FB45C0 /* Security.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -150,6 +153,7 @@
 				DD5DD92F2E742EFF00F93A3E /* CoreFoundation.framework */,
 				DD5DD92D2E742E9300F93A3E /* CoreVideo.framework */,
 				DD5DD92B2E742E4000F93A3E /* QuartzCore.framework */,
+				E9A1B0512CB0000000FB45C0 /* Security.framework */,
 				DD7A98DC2B22020000B3BF0D /* libblend2d.a */,
 				DD76254D290AFDC600BFE6D8 /* libboost_filesystem.a */,
 				DDBC4BC6282216890099E1F0 /* GLKit.framework */,


### PR DESCRIPTION
PR #354 のシステム CA 切替対応に伴い、Xcode プロジェクトで Security.framework が必要になったため追加します。